### PR TITLE
Multiple fixes around idempotency and check_mode

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -651,6 +651,7 @@ ubtu24cis_tmp_svc: false
 # The following variables are related to the set of rules from section 1.6.1.x
 
 ## Controls 1.3.1.3 and 1.3.1.4 Ensure all AppArmor Profiles are in enforce (1.3.1.3/4) or complain (1.3.1.3) mode
+control_1_3_1_4_was_run: false
 
 # This variable disables the implementation of rules 1.3.1.3 and 1.3.1.4
 # regarding enforcing profiles or putting them in complain mode

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -626,6 +626,10 @@ ubtu24cis_desktop_required: false
 # This will also purge any packages not removed via this playbook
 ubtu24cis_purge_apt: false
 
+## Ignore change_when for apt update task
+# Modifies behavior of 'changed_when' for 'apt update' task  in prelim that always changes
+ignore_apt_update_changed_when: false
+
 ##
 ## Section 1 Control Variables
 ##

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -55,6 +55,7 @@
   tags: always
   ansible.builtin.package:
     update_cache: true
+  changed_when: not ignore_apt_update_changed_when
 
 - name: Include audit specific variables
   when:

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -230,6 +230,7 @@
   tags: always
   ansible.builtin.shell: "grep ^log_file /etc/audit/auditd.conf | awk '{ print $NF }'"
   changed_when: false
+  check_mode: false
   failed_when: prelim_auditd_logfile.rc not in [ 0, 1 ]
   register: prelim_auditd_logfile
 

--- a/tasks/section_2/cis_2.1.x.yml
+++ b/tasks/section_2/cis_2.1.x.yml
@@ -699,7 +699,7 @@
       notify: Restart postfix
       ansible.builtin.lineinfile:
         path: /etc/postfix/main.cf
-        regexp: '^(#)?inet_interfaces'
+        regexp: '^(#)?inet_interfaces\s*=(?!\s*loopback-only\s*).*'
         line: 'inet_interfaces = loopback-only'
 
     - name: "2.1.21 | WARN | Ensure mail transfer agents are configured for local-only mode | Message out other main agents"

--- a/tasks/section_5/cis_5.4.1.x.yml
+++ b/tasks/section_5/cis_5.4.1.x.yml
@@ -130,13 +130,13 @@
     - login
   block:
     - name: "5.4.1.5 | AUDIT | Ensure inactive password lock is configured | General setting"
-      ansible.builtin.command: useradd -D | grep INACTIVE | cut -d= -f2
+      ansible.builtin.shell: useradd -D | grep INACTIVE | cut -d= -f2
       changed_when: false
       failed_when: false
       register: discovered_passwd_inactive_setting
 
     - name: "5.4.1.5 | PATCH | Ensure inactive password lock is configured| Set inactive period for new users"
-      when: discovered_passwd_inactive_setting.stdout != ubtu24cis_pass_inactive | string
+      when: discovered_passwd_inactive_setting.stdout != (ubtu24cis_pass_inactive | string)
       ansible.builtin.command: useradd -D -f {{ ubtu24cis_pass_inactive }}
       failed_when: false
       changed_when: true


### PR DESCRIPTION
**Overall Review of Changes:**
Number of fixes around idempotency and check_mode usage. My use-case also skips any tasks tagged with `level2-server` which causes some issues when evaluating variables.

**Issue Fixes:**
 - Update regexp for rule 2.1.21 to be more strict when updating line in file; allows task to be idempotent with itself
 - Update rule 5.4.1.5 to use shell task which supports pipes instead of command task; previously this would silently fail
 - Set a default variable value for `control_1_3_1_4_was_run` variable; if only level1-server tasks are executed, this variable is never set and tasks fail
 - If `prelim_auditd_logfile` in prelim stage does not evaluate, check mode will fail on rule 6.2.4.3 with `file () is absent, cannot continue` error

**Enhancements:**
 - Set `changed_when` for `apt update` task in prelim stage by introducing new role var `ignore_apt_update_changed_when`

**How has this been tested?:**
Tested using Ansible 2.16 and 2.18 where `level2-server` tagged tasks are skipped via `skip_tags` and a variety of rules are skipped via setting vars to `false`.

