### PR TITLE
make sure audit_log_dir exists, fix problem with tmout.sh file

### DIFF
--- a/tasks/pre_remediation_audit.yml
+++ b/tasks/pre_remediation_audit.yml
@@ -12,6 +12,12 @@
     mode: 'go-w'
     state: directory
 
+- name: Pre Audit Setup | Ensure existence of {{ audit_log_dir }}
+  ansible.builtin.file:
+    path: "{{ audit_log_dir }}"
+    mode: 'go-w'
+    state: directory
+
 - name: Pre Audit Setup | If using git for content set up
   when: audit_content == 'git'
   block:

--- a/tasks/section_5/cis_5.4.3.x.yml
+++ b/tasks/section_5/cis_5.4.3.x.yml
@@ -19,6 +19,21 @@
     regexp: nologin
     replace: ""
 
+- name: "5.4.3.2 | PATCH | Remove old content from {{ ubtu24cis_shell_session_file }} before adding new lines"
+  when:
+    - ubtu24cis_rule_5_4_3_2
+  tags:
+    - level1-server
+    - level1-workstation
+    - patch
+    - shell
+    - rule_5.4.3.2
+    - NIST800-53R5_NA
+  ansible.builtin.replace:
+    path: "{{ ubtu24cis_shell_session_file }}"
+    regexp: '# Logout Timeout\nexport TMOUT=0\nreadonly TMOUT\n'
+    replace: '# Logout Timeout\n'
+
 - name: "5.4.3.2 | PATCH | Ensure default user shell timeout is configured"
   when:
     - ubtu24cis_rule_5_4_3_2


### PR DESCRIPTION
* make sure audit_log_dir exists before writing logs (until now only audit_conf_dir is handled, leading to errors if they are not the same)
* fix problem with tmout.sh file on 24.04, when additional content is added and the previous content is still there (leading to error-messages upon login).

**Overall Review of Changes:**
Two small fixes to the playbook that I had running on several 24.04 machines.

**How has this been tested?:**
Ran the playbook on several machines setup from scratch with 24.04.
