### PR TITLE
Fix chrony sources owner

### DIFF
--- a/tasks/section_1/cis_1.2.2.x.yml
+++ b/tasks/section_1/cis_1.2.2.x.yml
@@ -10,7 +10,7 @@
     - NIST800-53R5_SI-2
     - patch
   block:
-    - name: "1.2.2.1 | PATCH | Ensure updates, patches, and additional security software are installedi | Update"
+    - name: "1.2.2.1 | PATCH | Ensure updates, patches, and additional security software are installed | Update"
       ansible.builtin.package:
         name: "*"
         state: latest

--- a/tasks/section_2/cis_2.3.3.x.yml
+++ b/tasks/section_2/cis_2.3.3.x.yml
@@ -16,8 +16,8 @@
         src: "{{ item }}.j2"
         dest: "/{{ item }}"
         mode: 'go-r'
-        owner: root
-        group: root
+        owner: _chrony
+        group: _chrony
       loop:
         - etc/chrony/sources.d/pool.sources
         - etc/chrony/sources.d/server.sources


### PR DESCRIPTION
**Overall Review of Changes:**
- chrony sources file owner and group are changed to `_chrony` from `root`. 
**Context:** The chrony daemon is patched to run by `_chrony` user in the [2.3.3.2 task](https://github.com/ansible-lockdown/UBUNTU24-CIS/blob/f90b698a57a9d6b823a6558b8087a49e2b26f1a0/tasks/section_2/cis_2.3.3.x.yml#L33) and cannot load files owned by root.
- fix typo



**How has this been tested?:**
Manual

