### PR TITLE
Correct variable names in pam_unix.j2 template.

### DIFF
--- a/templates/usr/share/pam-configs/pam_unix.j2
+++ b/templates/usr/share/pam-configs/pam_unix.j2
@@ -18,6 +18,6 @@ Session-Initial:
         required pam_unix.so
 Password-Type: Primary
 Password:
-        [success=end default=ignore] pam_unix.so obscure{% if ubtu24cis_rule_5.3.3.4.4 %} use_authtok{% endif %} try_first_pass{% if ubtu24cis_rule_5.3.3.4.3 %} {{ ubtu24cis_passwd_hash_algo }}{% endif %}
+        [success=end default=ignore] pam_unix.so obscure{% if ubtu24cis_rule_5_3_3_4_4 %} use_authtok{% endif %} try_first_pass{% if ubtu24cis_rule_5_3_3_4_3 %} {{ ubtu24cis_passwd_hash_algo }}{% endif %}
 Password-Initial:
-        [success=end default=ignore] pam_unix.so obscure{% if ubtu24cis_rule_5.3.3.4.3 %} {{ ubtu24cis_passwd_hash_algo }}{% endif %}
+        [success=end default=ignore] pam_unix.so obscure{% if ubtu24cis_rule_5_3_3_4_3 %} {{ ubtu24cis_passwd_hash_algo }}{% endif %}


### PR DESCRIPTION
**Overall Review of Changes:**
Fix the variable names in `templates/usr/share/pam-configs/pam_unix.j2`.

**Issue Fixes:**
Closes #53

**How has this been tested?:**
N/A

