### PR TITLE
Fixes typos in 1.5.x and 2.1.x

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -160,7 +160,7 @@
     name: "{{ ubtu24cis_time_sync_tool }}"
     state: restarted
 
-- name: Reload systemctl
+- name: Systemd_daemon_reload
   ansible.builtin.systemd:
     daemon_reload: true
 

--- a/tasks/section_1/cis_1.5.x.yml
+++ b/tasks/section_1/cis_1.5.x.yml
@@ -74,7 +74,7 @@
         owner: root
         group: root
         mode: 'go-r'
-      notify: Reload systemctl
+      notify: Systemd_daemon_reload
 
     - name: "1.5.3 | PATCH | Ensure core dumps are restricted | coredump.conf"
       ansible.builtin.lineinfile:

--- a/tasks/section_2/cis_2.1.x.yml
+++ b/tasks/section_2/cis_2.1.x.yml
@@ -423,7 +423,7 @@
         - ubtu24cis_rsync_mask
       notify: Systemd_daemon_reload
       ansible.builtin.systemd:
-        name: rsyncd.service
+        name: rsync.service
         enabled: false
         state: stopped
         masked: true


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
Fixes typos in 1.5.x and 2.1.x

**Issue Fixes:**
Some Notifies were not working because the handler name was not right.  Rsync service no longer named rsyncd

**Enhancements:**
Bug fixes

**How has this been tested?:**
tested on local systems
