### PR TITLE
Add missing config_aide conditional in 6.3.3

### DIFF
--- a/tasks/section_6/cis_6.3.x.yml
+++ b/tasks/section_6/cis_6.3.x.yml
@@ -112,6 +112,7 @@
 - name: "6.3.3 | Ensure cryptographic mechanisms are used to protect the integrity of audit tools"
   when:
     - ubtu24cis_rule_6_3_3
+    - ubtu24cis_config_aide
   tags:
     - level1-server
     - level1-workstation


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
Add missing config_aide conditional  in 6.3.3

**Issue Fixes:**
TASK [ubuntu-2404 : 6.3.3 | Ensure cryptographic mechanisms are used to protect the integrity of audit tools]
│ ***
│     fatal: [default]: FAILED! =>
│ {"changed": false, "msg": "Path /etc/aide/aide.conf does not exist !",
│ "rc": 257}

**Enhancements:**


**How has this been tested?:**
N/A

