### PR TITLE
fix content and syntax for 5.3.2.3 pam_pwquality

### DIFF
--- a/templates/usr/share/pam-configs/pwquality.j2
+++ b/templates/usr/share/pam-configs/pwquality.j2
@@ -4,5 +4,6 @@ Priority: 1024
 Conflicts: cracklib
 Password-Type: Primary
 Password:
-        requisite                       pam_pwquality.so retry=3 {#  # pragma: allowlist secret #}
-Password-Initial: requisite
+        requisite                       pam_pwquality.so retry=3{# # pragma: allowlist secret +#}
+Password-Initial:
+        requisite                       pam_pwquality.so retry=3{# # pragma: allowlist secret +#}


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**

Fix template content and syntax for 5.3.2.3 pam_pwquality

**Issue Fixes:**

#74 

**Enhancements:**

N/A

**How has this been tested?:**

Tested by running role with `--tags rule_5.3.2.3` and confirming `/usr/share/pam-configs/pwquality` template is generated with correct content for Password, Password-Inital, and syntax (no longer strips newlines), and subsequent `pam-auth-update` generates expected `/etc/pam.d/common-password` content with valid syntax.