### PR TITLE
Fix: corrected default umask to match login.defs

### DIFF
--- a/templates/etc/profile.d/50-umask.sh.j2
+++ b/templates/etc/profile.d/50-umask.sh.j2
@@ -4,4 +4,4 @@
 
 # Set umask with highest precedence
 
-umask 027
+umask {{ ubtu24cis_bash_umask }}


### PR DESCRIPTION
**Overall Review of Changes:**
This pull request updates the default _umask_ value in the `/etc/profile.d/50-umask.sh` template from `027` to the value of the `ubtu24cis_bash_umask` variable.

**Issue Fixes:**
#87 

**Enhancements:**
N/A

**How has this been tested?:**
Run a full hardening playbook in one of my systems using the updated template.
