### PR TITLE
fix 1.1.2.x audit message

### DIFF
--- a/tasks/section_1/cis_1.1.2.1.x.yml
+++ b/tasks/section_1/cis_1.1.2.1.x.yml
@@ -22,12 +22,12 @@
       register: discovered_tmp_mount
 
     - name: "1.1.2.1.1 | AUDIT | Ensure /tmp is a separate partition | Absent"
-      when: discovered_tmp_mount is undefined
+      when: discovered_tmp_mount is undefined or discovered_tmp_mount.stdout_lines == []
       ansible.builtin.debug:
         msg: "Warning!! {{ required_mount }} is not mounted on a separate partition"
 
     - name: "1.1.2.1.1 | AUDIT | Ensure /tmp is a separate partition | Present"
-      when: discovered_tmp_mount is undefined
+      when: discovered_tmp_mount is undefined or discovered_tmp_mount.stdout_lines == []
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 

--- a/tasks/section_1/cis_1.1.2.2.x.yml
+++ b/tasks/section_1/cis_1.1.2.2.x.yml
@@ -22,12 +22,12 @@
       register: discovered_dev_shm_mount
 
     - name: "1.1.2.2.1 | AUDIT | Ensure /dev/shm is a separate partition | Absent"
-      when: discovered_dev_shm_mount is undefined
+      when: discovered_dev_shm_mount is undefined or discovered_dev_shm_mount.stdout_lines == []
       ansible.builtin.debug:
         msg: "Warning!! {{ required_mount }} is not mounted on a separate partition"
 
     - name: "1.1.2.2.1 | AUDIT | Ensure /dev/shm is a separate partition | Present"
-      when: discovered_dev_shm_mount is undefined
+      when: discovered_dev_shm_mount is undefined or discovered_dev_shm_mount.stdout_lines == []
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 

--- a/tasks/section_1/cis_1.1.2.3.x.yml
+++ b/tasks/section_1/cis_1.1.2.3.x.yml
@@ -21,12 +21,12 @@
       register: discovered_home_mount
 
     - name: "1.1.2.3.1 | AUDIT | Ensure /home is a separate partition | Absent"
-      when: discovered_dev_shm_mount is undefined
+      when: discovered_home_mount is undefined or discovered_home_mount.stdout_lines == []
       ansible.builtin.debug:
         msg: "Warning!! {{ required_mount }} is not mounted on a separate partition"
 
     - name: "1.1.2.3.1 | AUDIT | Ensure /home is a separate partition | Present"
-      when: discovered_dev_shm_mount is undefined
+      when: discovered_home_mount is undefined or discovered_home_mount.stdout_lines == []
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 

--- a/tasks/section_1/cis_1.1.2.4.x.yml
+++ b/tasks/section_1/cis_1.1.2.4.x.yml
@@ -22,12 +22,12 @@
       register: discovered_var_mount
 
     - name: "1.1.2.4.1 | AUDIT | Ensure /var is a separate partition | Absent"
-      when: discovered_var_mount is undefined
+      when: discovered_var_mount is undefined or discovered_var_mount.stdout_lines == []
       ansible.builtin.debug:
         msg: "Warning!! {{ required_mount }} is not mounted on a separate partition"
 
     - name: "1.1.2.4.1 | AUDIT | Ensure /var is a separate partition | Present"
-      when: discovered_var_mount is undefined
+      when: discovered_var_mount is undefined or discovered_var_mount.stdout_lines == []
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 

--- a/tasks/section_1/cis_1.1.2.5.x.yml
+++ b/tasks/section_1/cis_1.1.2.5.x.yml
@@ -22,12 +22,12 @@
       register: discovered_var_tmp_mount
 
     - name: "1.1.2.5.1 | AUDIT | Ensure /var/tmp is a separate partition | Absent"
-      when: discovered_var_tmp_mount is undefined
+      when: discovered_var_tmp_mount is undefined or discovered_var_tmp_mount.stdout_lines == []
       ansible.builtin.debug:
         msg: "Warning!! {{ required_mount }} is not mounted on a separate partition"
 
     - name: "1.1.2.5.1 | AUDIT | Ensure /var/tmp is a separate partition | Present"
-      when: discovered_var_tmp_mount is undefined
+      when: discovered_var_tmp_mount is undefined or discovered_var_tmp_mount.stdout_lines == []
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 

--- a/tasks/section_1/cis_1.1.2.6.x.yml
+++ b/tasks/section_1/cis_1.1.2.6.x.yml
@@ -22,12 +22,12 @@
       register: discovered_var_log_mount
 
     - name: "1.1.2.6.1 | AUDIT | Ensure /var/log is a separate partition | Absent"
-      when: discovered_var_log_mount is undefined
+      when: discovered_var_log_mount is undefined or discovered_var_log_mount.stdout_lines == []
       ansible.builtin.debug:
         msg: "Warning!! {{ required_mount }} is not mounted on a separate partition"
 
     - name: "1.1.2.6.1 | AUDIT | Ensure /var/log is a separate partition | Present"
-      when: discovered_var_log_mount is undefined
+      when: discovered_var_log_mount is undefined or discovered_var_log_mount.stdout_lines == []
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 

--- a/tasks/section_1/cis_1.1.2.7.x.yml
+++ b/tasks/section_1/cis_1.1.2.7.x.yml
@@ -22,12 +22,12 @@
       register: discovered_var_log_audit_mount
 
     - name: "1.1.2.7.1 | AUDIT | Ensure /var/log/audit is a separate partition | Absent"
-      when: discovered_var_log_audit_mount is undefined
+      when: discovered_var_log_audit_mount is undefined or discovered_var_log_audit_mount.stdout_lines == []
       ansible.builtin.debug:
         msg: "Warning!! {{ required_mount }} is not mounted on a separate partition"
 
     - name: "1.1.2.7.1 | AUDIT | Ensure /var/log/audit is a separate partition | Present"
-      when: discovered_var_log_audit_mount is undefined
+      when: discovered_var_log_audit_mount is undefined or discovered_var_log_audit_mount.stdout_lines == []
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 


### PR DESCRIPTION
when mountpoints don't exist the variable will always exist and be the following:
```
    "discovered_tmp_mount": {
        "changed": false,
        "cmd": [
            "findmnt",
            "-kn",
            "/tmp"
        ],
        "delta": "0:00:00.004463",
        "end": "2026-02-12 07:52:25.486636",
        "failed": false,
        "failed_when_result": false,
        "failed_when_suppressed_exception": "(traceback unavailable)",
        "msg": "non-zero return code",
        "rc": 1,
        "start": "2026-02-12 07:52:25.482173",
        "stderr": "",
        "stderr_lines": [],
        "stdout": "",
        "stdout_lines": []
    }
}
```

so EVERY audit message will be skipped because 
`when: discovered_tmp_mount is undefined` will never be true