### PR TITLE
fix avahi package name

### DIFF
--- a/tasks/section_2/cis_2.1.x.yml
+++ b/tasks/section_2/cis_2.1.x.yml
@@ -50,7 +50,7 @@
       ansible.builtin.package:
         name:
           - avahi-autoipd
-          - avahi
+          - avahi-daemon
         state: absent
         purge: "{{ ubtu24cis_purge_apt }}"
 


### PR DESCRIPTION
there is no "avahi" package in ubuntu repo. and original cis benchmark states for avahi-daemon package, not just avahi.

```
apt-cache policy avahi
N: Unable to locate package avahi

---

apt  search  avahi | grep avahi
avahi-autoipd/noble-updates,noble-security 0.8-13ubuntu6.1 amd64
avahi-daemon/noble-updates,noble-security,now 0.8-13ubuntu6.1 amd64 [residual-config]
avahi-discover/noble-updates,noble-security 0.8-13ubuntu6.1 all
avahi-dnsconfd/noble-updates,noble-security 0.8-13ubuntu6.1 amd64
avahi-ui-utils/noble-updates,noble-security 0.8-13ubuntu6.1 amd64
avahi-utils/noble-updates,noble-security 0.8-13ubuntu6.1 amd64
```