### PR TITLE
1.1.20 change xorg-x11-server-common to xserver-common

### DIFF
--- a/tasks/section_2/cis_2.1.x.yml
+++ b/tasks/section_2/cis_2.1.x.yml
@@ -647,7 +647,7 @@
 - name: "2.1.20 | PATCH | Ensure X window server services are not in use"
   when:
     - not ubtu24cis_xwindow_server
-    - "'xorg-x11-server-common' in ansible_facts.packages"
+    - "'xserver-common' in ansible_facts.packages"
     - ubtu24cis_rule_2_1_20
   tags:
     - level2-server
@@ -656,7 +656,7 @@
     - rule_2.1.20
     - NIST800-53R5_CM-11
   ansible.builtin.package:
-    name: xorg-x11-server-common
+    name: xserver-common
     state: absent
     purge: "{{ ubtu24cis_purge_apt }}"
 


### PR DESCRIPTION
xorg-x11-server-common is a RHEL distro package: https://pkgs.org/search/?q=xorg-x11-server-common

CIS Benchmark mentions xorg-x11-server-common, BUT Remediation states clearly:
```apt purge xserver-common```
see this: https://pkgs.org/download/xserver-common - xserver-common is DEB-based OS package