### PR TITLE
[2.1.2] fix when condition for avahi

### DIFF
--- a/tasks/section_2/cis_2.1.x.yml
+++ b/tasks/section_2/cis_2.1.x.yml
@@ -46,7 +46,7 @@
       when:
         - not ubtu24cis_avahi_server
         - not ubtu24cis_avahi_mask
-        - "'avahi' in ansible_facts.packages or 'avahi-autoipd' in ansible_facts.packages"
+        - "'avahi-daemon' in ansible_facts.packages or 'avahi-autoipd' in ansible_facts.packages"
       ansible.builtin.package:
         name:
           - avahi-autoipd


### PR DESCRIPTION
```
    - name: "2.1.2 | PATCH | Ensure avahi daemon services are not in use | Remove package"
      when:
        - not ubtu24cis_avahi_server
        - not ubtu24cis_avahi_mask
        - "'avahi' in ansible_facts.packages or 'avahi-autoipd' in ansible_facts.packages"
      ansible.builtin.package:
        name:
          - avahi-autoipd
          - avahi-daemon
        state: absent
        purge: "{{ ubtu24cis_purge_apt }}"
```

when clause is wrong, because of searching avahi package and trying to delete avahi-daemon instead. should be avahi-daemon everywhere