### PR TITLE
[5.1.x] fix ssh keys permissions

### DIFF
--- a/tasks/section_5/cis_5.1.x.yml
+++ b/tasks/section_5/cis_5.1.x.yml
@@ -56,7 +56,7 @@
         path: "{{ item.path }}"
         owner: root
         group: root
-        mode: 'o-x,go-rwx'
+        mode: 'u-x,go-rwx'
       with_items:
         - "{{ discovered_ssh_host_priv_keys.files }}"
       loop_control:
@@ -84,7 +84,7 @@
         path: "{{ item.path }}"
         owner: root
         group: root
-        mode: 'go-wx'
+        mode: 'u-x,go-wx'
       with_items:
         - "{{ discovered_ssh_host_pub_keys.files }}"
       loop_control:


### PR DESCRIPTION
**5.1.2 Ensure permissions on SSH private host key files are configured (Automated)**
Audit:
Run the following script to verify SSH private host key files are owned by the root user and either:
- OR -
• owned by the group root and mode 0600 or more restrictive
• owned by the group designated to own openSSH private keys and mode 0640 or more restrictive

**5.1.3 Ensure permissions on SSH public host key files are configured (Automated)**
Audit:
Run the following script to verify SSH public host key files are mode 0644 or more restrictive, owned by the root user, and owned by the root group: