### PR TITLE
[5.3.3.1.3] fix regexp as in ubuntu 24.04 cis

### DIFF
--- a/tasks/section_5/cis_5.3.3.1.x.yml
+++ b/tasks/section_5/cis_5.3.3.1.x.yml
@@ -86,7 +86,7 @@
         mode: 'go-wx'
 
     - name: "5.3.3.1.3 | AUDIT | Ensure password failed attempts lockout includes root account | discover pam config with unlock_time"
-      ansible.builtin.shell: grep -Pl -- '\bpam_faillock\.so\h+([^#\n\r]+\h+)?(even_deny_root\b|root_unlock_time\s*=\s*\d+\b)' /usr/share/pam-configs/*
+      ansible.builtin.shell: grep -Pl -- '\bpam_faillock\.so\h+([^#\n\r]+\h+)?(even_deny_root|root_unlock_time)' /usr/share/pam-configs/*
       register: discovered_faillock_rootlock_files
       changed_when: false
       failed_when: discovered_faillock_rootlock_files.rc not in [ 0, 1 ]


### PR DESCRIPTION
<img width="1308" height="1124" alt="image" src="https://github.com/user-attachments/assets/03804fbc-e666-425c-949a-d0bad717880f" />
