### PR TITLE
[5.3.2, 5.3.3.3.1, 5.3.3.3.x] fix pam_pwhistory file generation

### DIFF
--- a/tasks/section_5/cis_5.3.3.3.x.yml
+++ b/tasks/section_5/cis_5.3.3.3.x.yml
@@ -19,7 +19,7 @@
       failed_when: discovered_pwhistory_remember.rc not in [0, 1]
 
     - name: "5.3.3.3.1 | PATCH | Ensure password number of changed characters is configured | Ensure remember is set"
-      when: discovered_pwhistory_remember.stdout | length > 0
+      when: discovered_pwhistory_remember.stdout | length == 0
       ansible.builtin.lineinfile:
         path: "/{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwhistory_file }}"
         regexp: ^(password\s+[^#\n\r]+\s+pam_pwhistory\.so\s+)(.*)(remember=\d+)
@@ -46,7 +46,7 @@
       failed_when: discovered_pwhistory_enforce_for_root.rc not in [0, 1]
 
     - name: "5.3.3.3.2 | PATCH | Ensure password history is enforced for the root user | Ensure remember is set"
-      when: discovered_pwhistory_enforce_for_root.stdout | length > 0
+      when: discovered_pwhistory_enforce_for_root.stdout | length == 0
       ansible.builtin.lineinfile:
         path: "/{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwhistory_file }}"
         regexp: ^(password\s+[^#\n\r]+\s+pam_pwhistory\.so\s+)(.*)(enforce_for_root)
@@ -73,7 +73,7 @@
       failed_when: discovered_pwhistory_use_authtok.rc not in [0, 1]
 
     - name: "5.3.3.3.3 | PATCH | Ensure pam_pwhistory includes use_authtok | Ensure remember is set"
-      when: discovered_pwhistory_use_authtok.stdout | length > 0
+      when: discovered_pwhistory_use_authtok.stdout | length == 0
       ansible.builtin.lineinfile:
         path: "/{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwhistory_file }}"
         regexp: ^(password\s+[^#\n\r]+\s+pam_pwhistory\.so\s+)(.*)(use_authtok)

--- a/templates/usr/share/pam-configs/pwhistory.j2
+++ b/templates/usr/share/pam-configs/pwhistory.j2
@@ -3,4 +3,4 @@ Default: yes
 Priority: 1024
 Password-Type: Primary
 Password:
-        requisite                       pam_pwhistory.so enforce_for_root try_first_pass{% if ubtu24cis_rule_5_3_3_3_1 %} remember={{ ubtu24cis_pamd_pwhistory_remember }}{% endif %}{% if ubtu24cis_rule_5_3_3_3_2 %} enforce_for_root{% endif %}{% if ubtu24cis_rule_5_3_3_3_3 %} use_authtok{% endif %}
+        requisite                       pam_pwhistory.so {% if ubtu24cis_rule_5_3_3_3_1 %} remember={{ ubtu24cis_pamd_pwhistory_remember }}{% endif %}{% if ubtu24cis_rule_5_3_3_3_2 %} enforce_for_root{% endif %}{% if ubtu24cis_rule_5_3_3_3_3 %} use_authtok{% endif %}


### PR DESCRIPTION
**5.3.2**
remove duplicates in jinja template. Audit regexp from ubuntu cis won't work ever because of this. (5.3.3.1)

**5.3.3.3.1, 5.3.3.3.2, 5.3.3.3.3**
fix when condition: if grep fails (no history string in pam config) - stdout will be empty and we won't check if right string goes in config file.

P.S.:
if ansible fails before running to the end we will never update pam, because all conditional checks with /usr/share will pass and never run handlers. This is true to all this kind of tasks.

P.P.S.:
something to think about: we put this file in ansible at 5.3.2 and full rewrite it. then in 5.3.3.3.1 we check line. maybe we should not do this at all? we believe that the center of truth is in 5.3.2. and notification of pam update is also there. why checking string second time in 5.3.3.3.1 (we don't check the value of pw_history, in fact we double-check ourselves that jinja template is correct)

