### PR TITLE
[6.1.1.1.3] make journald params more clear in defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1093,16 +1093,16 @@ ubtu24cis_journal_trustedcertificatefile:
 # Specify values in bytes or use K, M, G, T, P, E as units for the specified sizes.
 # See https://www.freedesktop.org/software/systemd/man/journald.conf.html for more information.
 # ATTENTION: Uncomment the keyword below when values are set!
-ubtu24cis_journald_systemmaxuse: "#SystemMaxUse="
-ubtu24cis_journald_systemkeepfree: "#SystemKeepFree="
-ubtu24cis_journald_runtimemaxuse: "#RuntimeMaxUse="
-ubtu24cis_journald_runtimekeepfree: "#RuntimeKeepFree="
+ubtu24cis_journald_systemmaxuse: "#SystemMaxUse=1G"
+ubtu24cis_journald_systemkeepfree: "#SystemKeepFree=500M"
+ubtu24cis_journald_runtimemaxuse: "#RuntimeMaxUse=200M"
+ubtu24cis_journald_runtimekeepfree: "#RuntimeKeepFree=50M"
 # This variable specifies, the maximum time to store entries in a single journal
 # file before rotating to the next one. Set to 0 to turn off this feature.
 # The given values is interpreted as seconds, unless suffixed with the units
 # `year`, `month`, `week`, `day`, `h` or `m` to override the default time unit of seconds.
 # ATTENTION: Uncomment the keyword below when values are set!
-ubtu24cis_journald_maxfilesec: "#MaxFileSec="
+ubtu24cis_journald_maxfilesec: "#MaxFileSec=1month"
 
 # 6.1.3.8 LOGRotate
 # Optional to alow logrotate to be installed

--- a/templates/etc/systemd/journald.conf.d/rotation.conf.j2
+++ b/templates/etc/systemd/journald.conf.d/rotation.conf.j2
@@ -1,8 +1,8 @@
 # File created for CIS benchmark
 # CIS rule 6_1_1_3
 [Journal]
-SystemMaxUse={{ ubtu24cis_journald_systemmaxuse }}
-SystemKeepFree={{ ubtu24cis_journald_systemkeepfree }}
-RuntimeMaxUse={{ ubtu24cis_journald_runtimemaxuse }}
-RuntimeKeepFree={{ ubtu24cis_journald_runtimekeepfree }}
-MaxFileSec={{ ubtu24cis_journald_maxfilesec }}
+{{ ubtu24cis_journald_systemmaxuse }}
+{{ ubtu24cis_journald_systemkeepfree }}
+{{ ubtu24cis_journald_runtimemaxuse }}
+{{ ubtu24cis_journald_runtimekeepfree }}
+{{ ubtu24cis_journald_maxfilesec }}


### PR DESCRIPTION
**if we do nothing:**
```
# File created for CIS benchmark
# CIS rule 6_1_1_3
[Journal]
SystemMaxUse=#SystemMaxUse=
SystemKeepFree=#SystemKeepFree=
RuntimeMaxUse=#RuntimeMaxUse=
RuntimeKeepFree=#RuntimeKeepFree=
MaxFileSec=#MaxFileSec=
```

**if we do like in default example**
```text
ubtu24cis_journald_systemmaxuse: "SystemMaxUse=1G"
ubtu24cis_journald_systemkeepfree: "SystemKeepFree=500M"
ubtu24cis_journald_runtimemaxuse: "RuntimeMaxUse=200M"
ubtu24cis_journald_runtimekeepfree: "RuntimeKeepFree=50M"
```
will get this:
```
# File created for CIS benchmark
# CIS rule 6_1_1_3
[Journal]
SystemMaxUse=SystemMaxUse=1G
SystemKeepFree=SystemKeepFree=500M
RuntimeMaxUse=RuntimeMaxUse=200M
RuntimeKeepFree=RuntimeKeepFree=50M
MaxFileSec=MaxFileSec=1month
```

**how we really might act with current jinja template**
```text
ubtu24cis_journald_systemmaxuse: "1G"
ubtu24cis_journald_systemkeepfree: "500M"
ubtu24cis_journald_runtimemaxuse: "200M"
ubtu24cis_journald_runtimekeepfree: "50M"
```
to get this:
```
# File created for CIS benchmark
# CIS rule 6_1_1_3
[Journal]
SystemMaxUse=1G
SystemKeepFree=500M
RuntimeMaxUse=200M
RuntimeKeepFree=50M
MaxFileSec=1month
```

so, let's clarify documentation and fix jinja template