### PR TITLE
[6.2.4.9] remove group permission setting in 6.2.4.9

### DIFF
--- a/tasks/section_6/cis_6.2.4.x.yml
+++ b/tasks/section_6/cis_6.2.4.x.yml
@@ -148,7 +148,6 @@
   ansible.builtin.file:
     path: "{{ item }}"
     owner: root
-    group: root
   loop: "{{ audit_bins }}"
 
 - name: "6.2.4.10 | PATCH | Ensure audit tools group owner is configured"


### PR DESCRIPTION
group ownership is set in 6.2.4.10. remove duplicate
potential risk of setting different groups in different tasks - must be only one source of truth