### PR TITLE
[4.2.5] Fix loop if allowed_out_ports in all

### DIFF
--- a/tasks/section_4/cis_4.2.x.yml
+++ b/tasks/section_4/cis_4.2.x.yml
@@ -112,7 +112,7 @@
         direction: out
         proto: "{{ item.proto }}"
         to_port: '{{ item.port }}'
-      loop: "{{ ubtu24cis_ufw_allow_out_ports }}"
+      loop: "{{ ubtu24cis_ufw_allow_out_ports if 'all' not in ubtu24cis_ufw_allow_out_ports else [] }}"
       loop_control:
         label: "{{ item.port }}"
       notify: Reload ufw


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
Loop was broken if ubtu24cis_ufw_allow_out_ports is set to all
Change backported from debian12 rule.

**Issue Fixes:**
#135 


