### PR TITLE
[2.4.1]/feature add control variable for cron allowed users

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -756,6 +756,9 @@ ubtu24cis_time_servers:
   - name: time-c-g.nist.gov
     options: iburst
 
+# List of users, allowed to use cron
+ubtu24cis_cron_allow_users: []
+
 ##
 ## Section 3 Control Variables
 ##

--- a/tasks/section_2/cis_2.4.1.x.yml
+++ b/tasks/section_2/cis_2.4.1.x.yml
@@ -141,17 +141,18 @@
 
     - name: "2.4.1.8 | PATCH | Ensure cron is restricted to authorized users | Create cron.allow if doesn't exist"
       when: not discovered_cron_allow_status.stat.exists
-      ansible.builtin.file:
-        path: /etc/cron.allow
+      ansible.builtin.copy:
+        dest: /etc/cron.allow
+        content: "{{ (ubtu24cis_cron_allow_users | default([])) | join('\n') ~ '\n' }}"
         owner: root
         group: root
         mode: "u-x,g-wx,o-rwx"
-        state: touch
 
     - name: "2.4.1.8 | PATCH | Ensure cron is restricted to authorized users |  Update cron.allow if exists"
       when: discovered_cron_allow_status.stat.exists
-      ansible.builtin.file:
-        path: /etc/cron.allow
+      ansible.builtin.copy:
+        dest: /etc/cron.allow
+        content: "{{ (ubtu24cis_cron_allow_users | default([])) | join('\n') ~ '\n' }}"
         owner: root
         group: '{{ (discovered_cron_allow_status.stat.gr_name == "crontab") | ternary(omit, "root") }}'
         mode: "u-x,g-wx,o-rwx"


### PR DESCRIPTION
add contol variable for /etc/cron.allow - list of users to be added to cron.allow