### PR TITLE
[section 5] Ensure pam update is triggered

### DIFF
--- a/tasks/section_5/cis_5.3.2.x.yml
+++ b/tasks/section_5/cis_5.3.2.x.yml
@@ -14,13 +14,49 @@
     - NIST800-53R5_IA-5
     - pam_auth_update
     - pam_unix
-  ansible.builtin.template:
-    src: "{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwunix_file }}.j2"
-    dest: "/{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwunix_file }}"
-    owner: root
-    group: root
-    mode: 'u-x,go-rwx'
-  notify: Pam_auth_update_pwunix
+  block:
+    - name: "5.3.2.1 | AUDIT | Ensure pam_unix module is enabled | Check existing files"
+      ansible.builtin.shell: grep -P -- '\bpam_unix\.so\b' /etc/pam.d/common-account
+      register: discovered_pam_unix_account
+      changed_when: false
+      failed_when: discovered_pam_unix_account.rc not in [0, 1]
+
+    - name: "5.3.2.1 | AUDIT | Ensure pam_unix module is enabled | Check existing files"
+      ansible.builtin.shell: grep -P -- '\bpam_unix\.so\b' /etc/pam.d/common-session
+      register: discovered_pam_unix_session
+      changed_when: false
+      failed_when: discovered_pam_unix_session.rc not in [0, 1]
+
+    - name: "5.3.2.1 | AUDIT | Ensure pam_unix module is enabled | Check existing files"
+      ansible.builtin.shell: grep -P -- '\bpam_unix\.so\b' /etc/pam.d/common-auth
+      register: discovered_pam_unix_auth
+      changed_when: false
+      failed_when: discovered_pam_unix_auth.rc not in [0, 1]
+
+    - name: "5.3.2.1 | AUDIT | Ensure pam_unix module is enabled | Check existing files"
+      ansible.builtin.shell: grep -P -- '\bpam_unix\.so\b' /etc/pam.d/common-password
+      register: discovered_pam_unix_password
+      changed_when: false
+      failed_when: discovered_pam_unix_password.rc not in [0, 1]
+
+    - name: "5.3.2.1 | PATCH | Ensure pam_unix module is enabled | Ensure template"
+      ansible.builtin.template:
+        src: "{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwunix_file }}.j2"
+        dest: "/{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwunix_file }}"
+        owner: root
+        group: root
+        mode: 'u-x,go-rwx'
+      notify: Pam_auth_update_pwunix
+
+    - name: "5.3.2.1 | PATCH | Ensure pam_unix module is enabled | Ensure notification is triggered"
+      when: (discovered_pam_unix_account.stdout | length == 0) OR
+            (discovered_pam_unix_session.stdout | length == 0) OR
+            (discovered_pam_unix_auth.stdout | length == 0) OR
+            (discovered_pam_unix_password.stdout | length == 0)
+      changed_when: true
+      ansible.builtin.debug:
+        msg: "Ensure notification is triggered"
+      notify: Pam_auth_update_pwunix
 
 - name: "5.3.2.2 | PATCH | Ensure pam_faillock module is enabled"
   when:

--- a/tasks/section_5/cis_5.3.2.x.yml
+++ b/tasks/section_5/cis_5.3.2.x.yml
@@ -15,25 +15,25 @@
     - pam_auth_update
     - pam_unix
   block:
-    - name: "5.3.2.1 | AUDIT | Ensure pam_unix module is enabled | Check existing files"
+    - name: "5.3.2.1 | AUDIT | Ensure pam_unix module is enabled | Check common-account for pam_unix.so"
       ansible.builtin.shell: grep -P -- '\bpam_unix\.so\b' /etc/pam.d/common-account
       register: discovered_pam_unix_account
       changed_when: false
       failed_when: discovered_pam_unix_account.rc not in [0, 1]
 
-    - name: "5.3.2.1 | AUDIT | Ensure pam_unix module is enabled | Check existing files"
+    - name: "5.3.2.1 | AUDIT | Ensure pam_unix module is enabled | Check common-session for pam_unix.so"
       ansible.builtin.shell: grep -P -- '\bpam_unix\.so\b' /etc/pam.d/common-session
       register: discovered_pam_unix_session
       changed_when: false
       failed_when: discovered_pam_unix_session.rc not in [0, 1]
 
-    - name: "5.3.2.1 | AUDIT | Ensure pam_unix module is enabled | Check existing files"
+    - name: "5.3.2.1 | AUDIT | Ensure pam_unix module is enabled | Check common-auth for pam_unix.so"
       ansible.builtin.shell: grep -P -- '\bpam_unix\.so\b' /etc/pam.d/common-auth
       register: discovered_pam_unix_auth
       changed_when: false
       failed_when: discovered_pam_unix_auth.rc not in [0, 1]
 
-    - name: "5.3.2.1 | AUDIT | Ensure pam_unix module is enabled | Check existing files"
+    - name: "5.3.2.1 | AUDIT | Ensure pam_unix module is enabled | Check common-password for pam_unix.so"
       ansible.builtin.shell: grep -P -- '\bpam_unix\.so\b' /etc/pam.d/common-password
       register: discovered_pam_unix_password
       changed_when: false
@@ -48,14 +48,14 @@
         mode: 'u-x,go-rwx'
       notify: Pam_auth_update_pwunix
 
-    - name: "5.3.2.1 | PATCH | Ensure pam_unix module is enabled | Ensure notification is triggered"
-      when: (discovered_pam_unix_account.stdout | length == 0) OR
-            (discovered_pam_unix_session.stdout | length == 0) OR
-            (discovered_pam_unix_auth.stdout | length == 0) OR
+    - name: "5.3.2.1 | PATCH | Ensure pam_unix module is enabled | Force pam-auth-update if pam_unix entries are missing"
+      when: (discovered_pam_unix_account.stdout | length == 0) or
+            (discovered_pam_unix_session.stdout | length == 0) or
+            (discovered_pam_unix_auth.stdout | length == 0) or
             (discovered_pam_unix_password.stdout | length == 0)
       changed_when: true
       ansible.builtin.debug:
-        msg: "Ensure notification is triggered"
+        msg: "pam_unix.so is missing from at least one /etc/pam.d/common-* file; forcing pam-auth-update."
       notify: Pam_auth_update_pwunix
 
 - name: "5.3.2.2 | PATCH | Ensure pam_faillock module is enabled"
@@ -72,20 +72,44 @@
     - NIST800-53R5_NA
     - pam_auth_update
     - pam_faillock
-  ansible.builtin.template:
-    src: "{{ ubtu24cis_pam_confd_dir }}{{ item }}.j2"
-    dest: "/{{ ubtu24cis_pam_confd_dir }}{{ item }}"
-    owner: root
-    group: root
-    mode: 'u-x,go-rwx'
-  loop:
-    - "{{ ubtu24cis_pam_faillock_file }}"
-    - "{{ ubtu24cis_pam_faillock_notify_file }}"
-  loop_control:
-    label: "{{ item }}"
-  notify:
-    - Pam_auth_update_pwfaillock
-    - Pam_auth_update_pwfaillock_notify
+  block:
+    - name: "5.3.2.2 | AUDIT | Ensure pam_faillock module is enabled | Check common-auth for pam_faillock.so"
+      ansible.builtin.shell: grep -P -- '\bpam_faillock\.so\b' /etc/pam.d/common-auth
+      register: discovered_pam_faillock_auth
+      changed_when: false
+      failed_when: discovered_pam_faillock_auth.rc not in [0, 1]
+
+    - name: "5.3.2.2 | AUDIT | Ensure pam_faillock module is enabled | Check common-account for pam_faillock.so"
+      ansible.builtin.shell: grep -P -- '\bpam_faillock\.so\b' /etc/pam.d/common-account
+      register: discovered_pam_faillock_account
+      changed_when: false
+      failed_when: discovered_pam_faillock_account.rc not in [0, 1]
+
+    - name: "5.3.2.2 | PATCH | Ensure pam_faillock module is enabled | Ensure templates"
+      ansible.builtin.template:
+        src: "{{ ubtu24cis_pam_confd_dir }}{{ item }}.j2"
+        dest: "/{{ ubtu24cis_pam_confd_dir }}{{ item }}"
+        owner: root
+        group: root
+        mode: 'u-x,go-rwx'
+      loop:
+        - "{{ ubtu24cis_pam_faillock_file }}"
+        - "{{ ubtu24cis_pam_faillock_notify_file }}"
+      loop_control:
+        label: "{{ item }}"
+      notify:
+        - Pam_auth_update_pwfaillock
+        - Pam_auth_update_pwfaillock_notify
+
+    - name: "5.3.2.2 | PATCH | Ensure pam_faillock module is enabled | Force pam-auth-update if pam_faillock entries are missing"
+      when: (discovered_pam_faillock_auth.stdout | length == 0) or
+            (discovered_pam_faillock_account.stdout | length == 0)
+      changed_when: true
+      ansible.builtin.debug:
+        msg: "pam_faillock.so is missing from /etc/pam.d/common-auth or common-account; forcing pam-auth-update."
+      notify:
+        - Pam_auth_update_pwfaillock
+        - Pam_auth_update_pwfaillock_notify
 
 - name: "5.3.2.3 | PATCH | Ensure pam_pwquality module is enabled"
   when:
@@ -100,13 +124,28 @@
     - NIST800-53R5_NA
     - pam_auth_update
     - pam_quality
-  ansible.builtin.template:
-    src: "{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwquality_file }}.j2"
-    dest: "/{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwquality_file }}"
-    owner: root
-    group: root
-    mode: 'u-x,go-rwx'
-  notify: Pam_auth_update_pwquality
+  block:
+    - name: "5.3.2.3 | AUDIT | Ensure pam_pwquality module is enabled | Check common-password for pam_pwquality.so"
+      ansible.builtin.shell: grep -P -- '\bpam_pwquality\.so\b' /etc/pam.d/common-password
+      register: discovered_pam_pwquality_password
+      changed_when: false
+      failed_when: discovered_pam_pwquality_password.rc not in [0, 1]
+
+    - name: "5.3.2.3 | PATCH | Ensure pam_pwquality module is enabled | Ensure template"
+      ansible.builtin.template:
+        src: "{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwquality_file }}.j2"
+        dest: "/{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwquality_file }}"
+        owner: root
+        group: root
+        mode: 'u-x,go-rwx'
+      notify: Pam_auth_update_pwquality
+
+    - name: "5.3.2.3 | PATCH | Ensure pam_pwquality module is enabled | Force pam-auth-update if pam_pwquality entries are missing"
+      when: discovered_pam_pwquality_password.stdout | length == 0
+      changed_when: true
+      ansible.builtin.debug:
+        msg: "pam_pwquality.so is missing from /etc/pam.d/common-password; forcing pam-auth-update."
+      notify: Pam_auth_update_pwquality
 
 - name: "5.3.2.4 | PATCH | Ensure pam_pwhistory module is enabled"
   when:
@@ -121,10 +160,25 @@
     - NIST800-53R5_NA
     - pam_auth_update
     - pam_history
-  ansible.builtin.template:
-    src: "{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwhistory_file }}.j2"
-    dest: "/{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwhistory_file }}"
-    owner: root
-    group: root
-    mode: 'u-x,go-rwx'
-  notify: Pam_auth_update_pwhistory
+  block:
+    - name: "5.3.2.4 | AUDIT | Ensure pam_pwhistory module is enabled | Check common-password for pam_pwhistory.so"
+      ansible.builtin.shell: grep -P -- '\bpam_pwhistory\.so\b' /etc/pam.d/common-password
+      register: discovered_pam_pwhistory_password
+      changed_when: false
+      failed_when: discovered_pam_pwhistory_password.rc not in [0, 1]
+
+    - name: "5.3.2.4 | PATCH | Ensure pam_pwhistory module is enabled | Ensure template"
+      ansible.builtin.template:
+        src: "{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwhistory_file }}.j2"
+        dest: "/{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwhistory_file }}"
+        owner: root
+        group: root
+        mode: 'u-x,go-rwx'
+      notify: Pam_auth_update_pwhistory
+
+    - name: "5.3.2.4 | PATCH | Ensure pam_pwhistory module is enabled | Force pam-auth-update if pam_pwhistory entries are missing"
+      when: discovered_pam_pwhistory_password.stdout | length == 0
+      changed_when: true
+      ansible.builtin.debug:
+        msg: "pam_pwhistory.so is missing from /etc/pam.d/common-password; forcing pam-auth-update."
+      notify: Pam_auth_update_pwhistory

--- a/tasks/section_5/cis_5.3.3.3.x.yml
+++ b/tasks/section_5/cis_5.3.3.3.x.yml
@@ -27,6 +27,13 @@
         backrefs: true
       notify: Pam_auth_update_pwhistory
 
+    - name: "5.3.3.3.1 | PATCH | Ensure password number of changed characters is configured | Ensure notification is triggered"
+      when: discovered_pwhistory_remember.stdout | length == 0
+      changed_when: true
+      ansible.builtin.debug:
+        msg: "Ensure notification is triggered"
+      notify: Pam_auth_update_pwhistory
+
 - name: "5.3.3.3.2 | PATCH | Ensure password history is enforced for the root user"
   when:
     - ubtu24cis_rule_5_3_3_3_2
@@ -54,6 +61,13 @@
         backrefs: true
       notify: Pam_auth_update_pwhistory
 
+    - name: "5.3.3.3.2 | PATCH | Ensure password history is enforced for the root user | Ensure notification is triggered"
+      when: discovered_pwhistory_enforce_for_root.stdout | length == 0
+      changed_when: true
+      ansible.builtin.debug:
+        msg: "Ensure notification is triggered"
+      notify: Pam_auth_update_pwhistory
+
 - name: "5.3.3.3.3 | PATCH | Ensure pam_pwhistory includes use_authtok"
   when:
     - ubtu24cis_rule_5_3_3_3_3
@@ -79,4 +93,11 @@
         regexp: ^(password\s+[^#\n\r]+\s+pam_pwhistory\.so\s+)(.*)(use_authtok)
         line: '\1\2\3 use_authtok'
         backrefs: true
+      notify: Pam_auth_update_pwhistory
+
+    - name: "5.3.3.3.3 | PATCH | Ensure pam_pwhistory includes use_authtok | Ensure notification is triggered"
+      when: discovered_pwhistory_use_authtok.stdout | length == 0
+      changed_when: true
+      ansible.builtin.debug:
+        msg: "Ensure notification is triggered"
       notify: Pam_auth_update_pwhistory

--- a/tasks/section_5/cis_5.3.3.3.x.yml
+++ b/tasks/section_5/cis_5.3.3.3.x.yml
@@ -28,11 +28,11 @@
         backrefs: true
       notify: Pam_auth_update_pwhistory
 
-    - name: "5.3.3.3.1 | PATCH | Ensure password number of changed characters is configured | Ensure notification is triggered"
+    - name: "5.3.3.3.1 | PATCH | Ensure password history remember is configured | Force pam-auth-update if pam_pwhistory remember entry is missing"
       when: discovered_pwhistory_remember.stdout | length == 0
       changed_when: true
       ansible.builtin.debug:
-        msg: "Ensure notification is triggered"
+        msg: "pam_pwhistory.so remember= entry is missing from /etc/pam.d/common-password; forcing pam-auth-update."
       notify: Pam_auth_update_pwhistory
 
 - name: "5.3.3.3.2 | PATCH | Ensure password history is enforced for the root user"
@@ -54,7 +54,7 @@
       failed_when: discovered_pwhistory_enforce_for_root.rc not in [0, 1]
       register: discovered_pwhistory_enforce_for_root
 
-    - name: "5.3.3.3.2 | PATCH | Ensure password history is enforced for the root user | Ensure remember is set"
+    - name: "5.3.3.3.2 | PATCH | Ensure password history is enforced for the root user | Ensure enforce_for_root is set"
       when: discovered_pwhistory_enforce_for_root.stdout | length == 0
       ansible.builtin.lineinfile:
         path: "/{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwhistory_file }}"
@@ -63,11 +63,11 @@
         backrefs: true
       notify: Pam_auth_update_pwhistory
 
-    - name: "5.3.3.3.2 | PATCH | Ensure password history is enforced for the root user | Ensure notification is triggered"
+    - name: "5.3.3.3.2 | PATCH | Ensure password history is enforced for the root user | Force pam-auth-update if pam_pwhistory enforce_for_root entry is missing"
       when: discovered_pwhistory_enforce_for_root.stdout | length == 0
       changed_when: true
       ansible.builtin.debug:
-        msg: "Ensure notification is triggered"
+        msg: "pam_pwhistory.so enforce_for_root entry is missing from /etc/pam.d/common-password; forcing pam-auth-update."
       notify: Pam_auth_update_pwhistory
 
 - name: "5.3.3.3.3 | PATCH | Ensure pam_pwhistory includes use_authtok"
@@ -89,7 +89,7 @@
       failed_when: discovered_pwhistory_use_authtok.rc not in [0, 1]
       register: discovered_pwhistory_use_authtok
 
-    - name: "5.3.3.3.3 | PATCH | Ensure pam_pwhistory includes use_authtok | Ensure remember is set"
+    - name: "5.3.3.3.3 | PATCH | Ensure pam_pwhistory includes use_authtok | Ensure use_authtok is set"
       when: discovered_pwhistory_use_authtok.stdout | length == 0
       ansible.builtin.lineinfile:
         path: "/{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwhistory_file }}"
@@ -98,9 +98,9 @@
         backrefs: true
       notify: Pam_auth_update_pwhistory
 
-    - name: "5.3.3.3.3 | PATCH | Ensure pam_pwhistory includes use_authtok | Ensure notification is triggered"
+    - name: "5.3.3.3.3 | PATCH | Ensure pam_pwhistory includes use_authtok | Force pam-auth-update if pam_pwhistory use_authtok entry is missing"
       when: discovered_pwhistory_use_authtok.stdout | length == 0
       changed_when: true
       ansible.builtin.debug:
-        msg: "Ensure notification is triggered"
+        msg: "pam_pwhistory.so use_authtok entry is missing from /etc/pam.d/common-password; forcing pam-auth-update."
       notify: Pam_auth_update_pwhistory


### PR DESCRIPTION
Example of notification improvement. 
Why?
if for any reason we can't run role to the end, pam update will never be triggered. 
so it's not idempotent without somehow rerunning notifications