### PR TITLE
[1.1.2.x] Fix tmp.mount systemd service

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -598,8 +598,18 @@ ubtu24cis_debug_mount_data: false
 ## Control 1.1.2.x
 # If set to `true`, rule will be implemented using the `tmp.mount` systemd-service,
 # otherwise fstab configuration will be used.
-# These /tmp settings will include nosuid,nodev,noexec to conform to CIS standards.
+# Default value is `false`, which means that the fstab configuration will be used for /tmp partition.
+# If set to `true`, mount options for /tmp can be set using the `tmp_partition_mount_options` variable below.
 ubtu24cis_tmp_svc: false
+
+## Control 1.1.2.x - tmp_partition_mount_options
+# When `ubtu24cis_tmp_svc` is set to `true`, the mount options for /tmp will be set in the `tmp.mount` systemd-service.
+# This variable only applies if `ubtu24cis_tmp_svc` is set to `true`.
+# Default value is `nosuid,nodev,noexec`, which is the recommended setting for /tmp according to CIS standards.
+tmp_partition_mount_options:
+  - nosuid
+  - nodev
+  - noexec
 
 ## Controls 1.3.1.x - apparmor
 # AppArmor security policies define what system resources applications can access and their privileges.

--- a/templates/etc/systemd/system/tmp.mount.j2
+++ b/templates/etc/systemd/system/tmp.mount.j2
@@ -11,7 +11,7 @@ What=tmpfs
 Where=/tmp
 Type=tmpfs
 
-Options: {{ tmp_partition_mount_options | unique | join(',') }}
+Options={{ tmp_partition_mount_options | unique | join(',') }}
 
 [Install]
 WantedBy=local-fs.target


### PR DESCRIPTION
**Overall Review of Changes:**

Setting `ubtu24cis_tmp_svc: true` results in an error when trying to configure the service due to an undefined variable:
```
FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'tmp_partition_mount_options' is undefined. 'tmp_partition_mount_options' is undefined"}
```

In addition, the template generates a systemd-service unit file that has an invalid option:
```
vagrant@vagrant:~$ sudo cat /etc/systemd/system/tmp.mount
[Unit]
Description=Temporary Directory /tmp
ConditionPathIsSymbolicLink=!/tmp
DefaultDependencies=no
Conflicts=umount.target
Before=local-fs.target umount.target
After=swap.target

[Mount]
What=tmpfs
Where=/tmp
Type=tmpfs

Options: mode=1777,strictatime,nodev,nosuid,noexec

[Install]
WantedBy=local-fs.target
vagrant@vagrant:~$ systemctl show -p Options --value tmp.mount
rw,nosuid,nodev,noexec,inode64
vagrant@vagrant:~$ systemctl status tmp.mount
- tmp.mount - Temporary Directory /tmp
     Loaded: loaded (/proc/self/mountinfo; disabled; preset: enabled)
     Active: active (mounted) since Thu 2026-04-16 19:11:14 UTC; 1h 7min ago
      Where: /tmp
       What: tmpfs
      Tasks: 0 (limit: 3470)
     Memory: 4.0K (peak: 1.6M)
        CPU: 24ms
     CGroup: /system.slice/tmp.mount

Apr 16 19:11:14 vagrant systemd[1]: tmp.mount: Directory /tmp to mount over is not empty, mounting anyway.
Apr 16 19:11:14 vagrant systemd[1]: Mounting tmp.mount - Temporary Directory (/tmp)...
Apr 16 19:11:14 vagrant systemd[1]: Mounted tmp.mount - Temporary Directory (/tmp).
Apr 16 20:11:43 vagrant systemd[1]: /etc/systemd/system/tmp.mount:14: Unknown key name 'Options: mode' in section 'Mount', ignoring.
Apr 16 20:11:43 vagrant systemd[1]: /etc/systemd/system/tmp.mount:14: Unknown key name 'Options: mode' in section 'Mount', ignoring.
Apr 16 20:13:12 vagrant systemd[1]: /etc/systemd/system/tmp.mount:14: Unknown key name 'Options: mode' in section 'Mount', ignoring.
Apr 16 20:13:58 vagrant systemd[1]: /etc/systemd/system/tmp.mount:14: Unknown key name 'Options: mode' in section 'Mount', ignoring.
Apr 16 20:14:00 vagrant systemd[1]: /etc/systemd/system/tmp.mount:14: Unknown key name 'Options: mode' in section 'Mount', ignoring.
Apr 16 20:14:01 vagrant systemd[1]: /etc/systemd/system/tmp.mount:14: Unknown key name 'Options: mode' in section 'Mount', ignoring.
vagrant@vagrant:~$
```

**Issue Fixes:**
n/a

**Enhancements:**
Since `defaults/main.yml` suggests that  the default options for `/tmp` when using systemd are `nosuid,nodev,noexec`, adding the undefined variable to `defaults/main.yml` with these defaults. It seems the template is the only place this variable is used, so shouldn't cause any issues anywhere else.

In addition, updated the template (`templates/etc/systemd/system/tmp.mount.j2`) to replace the invalid character.

**How has this been tested?:**
The undefined variable was first encountered during a build process. After the build failed, decided to test it in `vagrant` to verify Ansible would run properly. After it ran (with passing values to `tmp_partition_mount_options`, checked the tmp.mount service and noticed the warnings (see the block above).

To further test and verify the issue, checked the options for `/tmp` and verified they were incorrect. After fixing the service file and restarting the service, verified then that the options were as expected.

Here's a screen showing the full process (options with the systemd-service file as deployed, modified the service file, then verified the options again to confirm the fix):
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/93b0f3ba-7326-454c-9c7d-582a77a0d0ad" />

