### PR TITLE
removes wildcard from pam files replace rule 5.3.3.4.1,2

### DIFF
--- a/tasks/section_5/cis_5.3.3.4.x.yml
+++ b/tasks/section_5/cis_5.3.3.4.x.yml
@@ -15,7 +15,7 @@
     - name: "5.3.3.4.1 | PATCH | Ensure pam_unix does not include nullok | capture state"
       ansible.builtin.shell: |
         set -o pipefail
-        grep -E "pam_unix.so.*nullok" /etc/pam.d/common-* /usr/share/pam-configs/* | cut -d ':' -f1 | uniq
+        grep -E "pam_unix.so.*nullok" /etc/pam.d/common-{password,auth,account,session,session-noninteractive} /usr/share/pam-configs/* | cut -d ':' -f1 | uniq
       args:
         executable: /bin/bash
       changed_when: false
@@ -47,7 +47,7 @@
     - name: "5.3.3.4.2 | AUDIT | Ensure pam_unix does not include remember | capture state"
       ansible.builtin.shell: |
         set -o pipefail
-        grep -PH -- '^\h*^\h*[^#\n\r]+\h+pam_unix\.so\b' /etc/pam.d/common-* | grep -P -- "remember=\d+" | cut -d':' -f1
+        grep -PH -- '^\h*^\h*[^#\n\r]+\h+pam_unix\.so\b' /etc/pam.d/common-{password,auth,account,session,session-noninteractive} | grep -P -- "remember=\d+" | cut -d':' -f1
       args:
         executable: /bin/bash
       changed_when: false


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
Removed wildcard from regex on some pam modification

**Issue Fixes:**
This fixes wild cards finding backup files that could exist with the same filename and aligns with the instructions in the CIS benchmark.

**Enhancements:**
Aligns with the CIS benchmark as it is written.

**How has this been tested?:**
Tested locally
