### PR TITLE
Fix 5.1.18, create /run/sshd, fix apt cache

### DIFF
--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -82,8 +82,8 @@
 
 - name: "PRELIM | PATCH | Run apt update"
   tags: always
-  ansible.builtin.package:
-    cache_valid_time: 3600
+  ansible.builtin.apt:
+    update_cache: yes
     lock_timeout: "{{ ubtu24cis_apt_lock_timeout }}"
   changed_when: not ubtu24cis_ignore_apt_update_changed_when
 

--- a/tasks/section_5/cis_5.1.x.yml
+++ b/tasks/section_5/cis_5.1.x.yml
@@ -103,6 +103,14 @@
     - NIST800-53R5_MP-2
     - sshd
   block:
+    - name: Ensure /run/sshd exists for sshd -t validation
+      ansible.builtin.file:
+        path: /run/sshd
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+
     - name: "5.1.4 | PATCH | Ensure sshd access is configured | Add allowed users"
       when: "ubtu24cis_sshd_allow_users| default('') | length > 0 "
       ansible.builtin.lineinfile:
@@ -407,6 +415,8 @@
     path: /etc/ssh/sshd_config
     regexp: (?i)^(#?)\s*MaxStartups
     line: 'MaxStartups 10:30:60'
+    insertbefore: '^Match'
+    firstmatch: true
     validate: 'sshd -t -f %s'
   notify: Restart sshd
 


### PR DESCRIPTION
1. update caches

**story:** we create vm's with packer on vmware from iso. apply ansible role with internal repos. then run cis role.

**problem:** prelim package module doesn't update cache. this module even doesn't have cache option. so, we fail when trying to install auditd in prelim. i think that there is no reason not to use apt module in ubuntu role - we are 100% sure it's apt-compatible.

2. Fixed bug: Directive 'MaxStartups' is not allowed within a Match block
3. create temporary /run/sshd because of "failed to validate: rc:255 error:Missing privilege separation directory: /run/sshd"

