### PR TITLE
fix 1.4.1 Ensure bootloader password is set

### DIFF
--- a/tasks/section_1/cis_1.4.x.yml
+++ b/tasks/section_1/cis_1.4.x.yml
@@ -18,7 +18,7 @@
         dest: "{{ ubtu24cis_grub_user_file }}"
         owner: root
         group: root
-        mode: 'go-w'
+        mode: 'u=rwx,go=rx'
       notify: Grub update
 
     - name: "1.4.1 | PATCH | Ensure bootloader password is set | allow unrestricted boot"


### PR DESCRIPTION
```
# chmod +x /etc/grub.d/00_user
# update-grub
# grep -A2 password_pbkdf2 /boot/grub/grub.cfg
....   password_pbkdf2 root  .....
# chmod -x /etc/grub.d/00_user
# update-grub
# grep -A2 password_pbkdf2 /boot/grub/grub.cfg
--->>> empty output <<<---