### PR TITLE
fix: change tags for 1.1.2.X.1 to correctly match CIS Level 2

### DIFF
--- a/tasks/section_1/cis_1.1.2.3.x.yml
+++ b/tasks/section_1/cis_1.1.2.3.x.yml
@@ -4,8 +4,8 @@
     - ubtu24cis_rule_1_1_2_3_1
     - required_mount not in prelim_mount_names
   tags:
-    - level1-server
-    - level1-workstation
+    - level2-server
+    - level2-workstation
     - audit
     - mounts
     - rule_1.1.2.3.1

--- a/tasks/section_1/cis_1.1.2.4.x.yml
+++ b/tasks/section_1/cis_1.1.2.4.x.yml
@@ -5,8 +5,8 @@
     - ubtu24cis_rule_1_1_2_4_1
     - required_mount not in prelim_mount_names
   tags:
-    - level1-server
-    - level1-workstation
+    - level2-server
+    - level2-workstation
     - audit
     - mounts
     - rule_1.1.2.4.1

--- a/tasks/section_1/cis_1.1.2.5.x.yml
+++ b/tasks/section_1/cis_1.1.2.5.x.yml
@@ -5,8 +5,8 @@
     - ubtu24cis_rule_1_1_2_5_1
     - required_mount not in prelim_mount_names
   tags:
-    - level1-server
-    - level1-workstation
+    - level2-server
+    - level2-workstation
     - audit
     - mounts
     - rule_1.1.2.5.1

--- a/tasks/section_1/cis_1.1.2.6.x.yml
+++ b/tasks/section_1/cis_1.1.2.6.x.yml
@@ -5,8 +5,8 @@
     - ubtu24cis_rule_1_1_2_6_1
     - required_mount not in prelim_mount_names
   tags:
-    - level1-server
-    - level1-workstation
+    - level2-server
+    - level2-workstation
     - audit
     - mounts
     - rule_1.1.2.6.1

--- a/tasks/section_1/cis_1.1.2.7.x.yml
+++ b/tasks/section_1/cis_1.1.2.7.x.yml
@@ -5,8 +5,8 @@
     - ubtu24cis_rule_1_1_2_7_1
     - required_mount not in prelim_mount_names
   tags:
-    - level1-server
-    - level1-workstation
+    - level2-server
+    - level2-workstation
     - audit
     - mounts
     - rule_1.1.2.7.1


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
Rule tags for 1.1.2.3.1, 1.1.2.4.1, 1.1.2.5.1, 1.1.2.6.1 & 1.1.2.7.1 are updated to correctly match CIS

**Issue Fixes:**
N/A

**Enhancements:**
Aligns with the CIS benchmark as it is written.

**How has this been tested?:**
N/A

