### PR TITLE
Add os_check variable to bypass distribution/release assertion

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+# Run the OS validation check
+# Supported OSs will not need for this to be changed - see README
+os_check: true
 
 # defaults file for UBUNTU24-CIS
 # WARNING:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,7 @@
 
 - name: Check OS version and family
   when:
+    - os_check is truthy
     - ansible_facts.distribution == 'Ubuntu'
     - ansible_facts.distribution_major_version is version_compare('24', '!=')
   tags: always


### PR DESCRIPTION
Hi, others playbooks (eg: Debian 12) have the ability to bypass the os check, which comes handy to test the latest OS versions. This commit implements it for this playbook.

Signed-off-by: seven beep <ebn@entreparentheses.xyz>