### PR TITLE
fix tmp mount handlers

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -13,6 +13,7 @@
   listen: "Remount /tmp"
 
 - name: "Remounting /tmp"
+  when: ubtu24cis_tmp_svc is falsy
   vars:
     mount_point: '/tmp'
   ansible.posix.mount:
@@ -21,12 +22,10 @@
   listen: "Remount /tmp"
 
 - name: "Remounting /tmp systemd"
-  when: ubtu24cis_tmp_svc
-  vars:
-    mount_point: '/tmp'
+  when: ubtu24cis_tmp_svc is truthy
   ansible.builtin.systemd:
     name: tmp.mount
-    state: restarted
+    state: reloaded
     daemon_reload: true
   listen: "Remount /tmp"
 


### PR DESCRIPTION
ubtu24cis_tmp_svc should be checked on both handlers or both handlers would be
run.

The correct way to remount an mount unit is to use reloaded. Restarted would
only work if the mount unit was not yet started and fails otherwise as the
target would be busy. Also reloaded ensure the unit is started.