### PR TITLE
Exclude necessary dot files from automated modification

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1583,7 +1583,9 @@ ubtu24cis_ownership_adjust: true
 ubtu24cis_suid_sgid_adjust: false
 
 ## Control 7.2.10 - Ensure local interactive user dot files access is configured
-# This variable is a toggle foe enabling/disabling the automated modification of
+# This variable is a toggle for enabling/disabling the automated modification of
 # permissions on dot files.
 # Possible values are `true` and `false`.
 ubtu24cis_dotperm_ansiblemanaged: true
+# This variable allows to exclude only necessary files (i.e. ['.xinitrc'])
+ubtu24cis_dotfile_exclusions: []

--- a/tasks/section_7/cis_7.2.x.yml
+++ b/tasks/section_7/cis_7.2.x.yml
@@ -335,7 +335,7 @@
     - name: "7.2.10 | AUDIT | Ensure local interactive user dot files access is configured"
       ansible.builtin.shell: |
         set -o pipefail
-        find {{ prelim_interactive_users_home.stdout_lines | list | join(' ') }} -name "\.*" -type f
+        find {{ prelim_interactive_users_home.stdout_lines | list | join(' ') }} -name "\.*" -type f{% for f in ubtu24cis_dotfile_exclusions %} ! -name "{{ f }}"{% endfor %}
       args:
         executable: /bin/bash
       changed_when: false


### PR DESCRIPTION
some kiosk-mode servers need .xinitrc file to be executable. 
maybe we can parametrise this with ubtu24cis_desktop_required variable (if true - than exlude .xinitrc)

