### PR TITLE
July26 sync

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,21 @@
 Contributing to Ansible-Lockdown Projects
-========================================
+=========================================
 
 Rules
 -----
+
 1) All commits must be GPG signed (details in Signing section)
 2) All commits must have Signed-off-by (Signed-off-by: Joan Doe <joan.doe@email.com>) in the commit message (details in Signing section)
-3) All work is done in your own branch
-4) All pull requests go into the devel branch. There are automated checks for signed commits, signoff in commit message, and functional testing)
-5) Be open and nice to each other
+3) All work is done in your own branch or own fork
+4) Pull requests
+    a) From within the repo: All pull requests go into the devel branch. There are automated checks for signed commits, signoff in commit message, and functional testing
+    b) From a forked repo: All pull requests will go into a staging branch within the repo. There are automated checks for signed commits, signoff in commit message, and functional testing when going from staging to devel
+5) All pull requests go into the devel branch. There are automated checks for signed commits, signoff in commit message, and functional testing)
+6) Be open and nice to each other
 
 Workflow
 --------
+
 - Your work is done in your own individual branch. Make sure to Signed-off and GPG sign all commits you intend to merge
 - All community Pull Requests are into the devel branch. There are automated checks for GPG signed, Signed-off in commits, and functional tests before being approved. If your pull request comes in from outside of our repo, the pull request will go into a staging branch. There is info needed from our repo for our CI/CD testing.
 - Once your changes are merged and a more detailed review is complete, an authorized member will merge your changes into the main branch for a new release
@@ -20,7 +25,7 @@ Signing your contribution
 
 We've chosen to use the Developer's Certificate of Origin (DCO) method
 that is employed by the Linux Kernel Project, which provides a simple
-way to contribute to Ansible-Lockdown projects.
+way to contribute to MindPoint Group projects.
 
 The process is to certify the below DCO 1.1 text
 ::

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,60 +1,96 @@
 # Ubuntu24CIS
 
+## Based on CIS v1.0.0 - July 2026
+
+### Fixed
+
+- tasks/section_2/cis_2.1.x.yml line 642: Corrected service name typo `ngnix.service` to `nginx.service`
+- defaults/main.yml: Set `audit_run_heavy_tests` default to `false` (opt-in convention — avoids slow tests in CI by default)
+- defaults/main.yml: Moved 7 internal audit constants to `vars/audit.yml` where they belong (`audit_max_concurrent`, `get_audit_binary_method`, `audit_bin_copy_location`, `audit_content`, `audit_conf_source`, `audit_conf_dest`, `audit_log_dir`) — these are role implementation details that should not be user-overridable
+- vars/CIS.yml (audit repo): Corrected `benchmark_version` from `2.0.0` to `1.0.0`
+- molecule/localhost/converge.yml, molecule/wsl/converge.yml: Added `setup_audit: true` and `run_audit: true` so molecule runs the full audit on converge
+- .github/workflows/export_badges_public.yml: Removed — this workflow is for public mirrors only and must not be present in a private repo
+- CONTRIBUTING.md: Added — was missing from remediation repo
+- 15 manual controls: Changed tag from `patch` to `audit` — these controls require manual intervention and must not perform active remediation: 1.1.1.10, 1.2.2.1, 3.1.1, 4.2.5, 4.4.2.3, 4.4.3.3, 5.3.3.2.3, 5.4.1.2, 6.1.1.3, 6.1.2.1.2, 6.1.3.5, 6.1.3.6, 6.1.3.8, 6.2.3.21
+- updated 1.1.1.10 to be able to set location the script runs from
+- ability to change default shell for shell module calls
+- Converted ansible dot-notation references to bracket notation
+- improved 5.2.4 tests and prelim check
+- aligned audit variable naming wih remediation vars
+- removed unneeded handlers
+- tidy up audit variables
+- Thanks to @bykvaadm
+  - #157 PAM update
+  - #168 sshd fix
+  - #169 bootloader file permissions also thanks to @alexmroke
+  - #176 dot file. excludion addition 7.2.10
+- Thanks to seven-beep
+  - #171 os_check addition
+- thanks to @dderemiah
+  - #167 pam improvements
+- thanks to @hackery
+  - #175 overlay mod change 1.1.1.6
+- thanks to @defnotyujine
+  - tmp mount handler changed to import_tasks
+- 100 task files: Converted `ansible_facts` dot notation to bracket notation throughout `tasks/` and `vars/`
+- Added `set -o pipefail` and `args: executable: /bin/bash` to tasks with pipes
+- templates/ansible_vars_goss.yml.j2: Renamed to `templates/lockdown_audit.yml.j2`  updated reference in `tasks/pre_remediation_audit.yml`
+
 ## Based on CIS v1.0.0 - Branch [2026_April_QA]
 
 ### QA Validation
 
-**Molecule Results:** Converge PASSED (ok=151, changed=7, failed=0), Verify PASSED (audit: 122 failures)
+Molecule Results: Converge PASSED (ok=151, changed=7, failed=0), Verify PASSED (audit: 122 failures)
 
 #### Fixed (Pre-QA Checks)
 
-- **vars/CIS.yml (audit):** Fixed benchmark_version from '2.0.0' to '1.0.0'
-- **README.md:** Removed RHEL dependencies (python-def, libselinux-python), updated to Python3.12+/Ansible 2.16+
-- **.gitignore:** Added secret file patterns and QA artifact patterns
-- **tasks/main.yml:** Added `community.docker.docker` to container connection detection
+- vars/CIS.yml (audit): Fixed benchmark_version from '2.0.0' to '1.0.0'
+- README.md: Removed RHEL dependencies (python-def, libselinux-python), updated to Python3.12+/Ansible 2.16+
+- .gitignore: Added secret file patterns and QA artifact patterns
+- tasks/main.yml: Added `community.docker.docker` to container connection detection
 
 #### Changed (Standards Alignment)
 
-- **48 shell tasks:** Added `set -o pipefail` with `args: executable: /bin/bash`
-- **cis_2.1.x.yml, cis_3.1.x.yml:** Applied package-aware ternary masking to 21 systemd mask tasks
-- **62 discovery tasks:** Added `check_mode: false`
-- **44 discovery tasks:** Specific `failed_when: <var>.rc not in [0, 1]` replacing broad `failed_when: false`
-- **5 tasks:** Fixed absolute mode notation to relative
-- **12 tasks:** Converted single-item `when:`/`notify:` to inline
-- **80 loop tasks:** Added `loop_control: label`
+- 48 shell tasks: Added `set -o pipefail` with `args: executable: /bin/bash`
+- cis_2.1.x.yml, cis_3.1.x.yml: Applied package-aware ternary masking to 21 systemd mask tasks
+- 62 discovery tasks: Added `check_mode: false`
+- 44 discovery tasks: Specific `failed_when: <var>.rc not in [0, 1]` replacing broad `failed_when: false`
+- 5 tasks: Fixed absolute mode notation to relative
+- 12 tasks: Converted single-item `when:`/`notify:` to inline
+- 80 loop tasks: Added `loop_control: label`
 
 #### Security
 
-- **7 tasks:** Added `no_log: true` to `/etc/shadow` tasks
+- 7 tasks: Added `no_log: true` to `/etc/shadow` tasks
 
 #### Fixed (Molecule Findings)
 
-- **vars/is_container.yml:** Added missing `ubtu24cis_rule_6_2_2_4`
-- **3 escaped quotes:** Fixed after pipefail conversion
-- **7 pwck tasks:** Reverted to `failed_when: false` (SIGPIPE rc=141)
+- vars/is_container.yml: Added missing `ubtu24cis_rule_6_2_2_4`
+- 3 escaped quotes: Fixed after pipefail conversion
+- 7 pwck tasks: Reverted to `failed_when: false` (SIGPIPE rc=141)
 
 #### Added
 
-- **molecule/default/:** Docker test scenario for Ubuntu 24.04 with audit verification
-- **molecule/localhost/:** Delegated local test scenario
-- **molecule/wsl/:** WSL delegated test scenario
+- molecule/default/: Docker test scenario for Ubuntu 24.04 with audit verification
+- molecule/localhost/: Delegated local test scenario
+- molecule/wsl/: WSL delegated test scenario
 
 #### Title Alignment
 
-- **92 task titles:** Updated to match CIS Ubuntu Linux 24.04 LTS Benchmark v1.0.0 titles exactly
+- 92 task titles: Updated to match CIS Ubuntu Linux 24.04 LTS Benchmark v1.0.0 titles exactly
 
 #### Additional Fixes
 
-- **defaults/main.yml:** Aligned header structure with UB22 standard — added role identification, variable precedence warning, `system_is_container`, UID discovery variables, `system_is_ec2`, `skip_for_test`. Removed duplicate variables.
-- **meta/main.yml, vars/main.yml:** Updated `min_ansible_version` from 2.12.1 to 2.16.1
-- **vars/main.yml:** Fixed `company_title` casing — `Mindpoint` → `MindPoint`
+- defaults/main.yml: Aligned header structure with UB22 standard — added role identification, variable precedence warning, `system_is_container`, UID discovery variables, `system_is_ec2`, `skip_for_test`. Removed duplicate variables.
+- meta/main.yml, vars/main.yml: Updated `min_ansible_version` from 2.12.1 to 2.16.1
+- vars/main.yml: Fixed `company_title` casing — `Mindpoint` → `MindPoint`
 
 #### Issue Resolution
 
-- **tasks/prelim.yml:** Fixed mount option gathering to preserve `/etc/fstab` source entries (UUID=, PARTUUID=, LABEL=) instead of using volatile `/dev/sdX` device names from `mount` output — addresses #162, thank you @samicemalone
-- **defaults/main.yml:** Added commented `sntrup761x25519-sha512` post-quantum KEX algorithm option — addresses #156, thank you @cagriersen
-- **templates/tmp.mount.j2:** Fixed systemd mount unit syntax `Options:` → `Options=` — addresses PR #163, thank you @kevingunn-wk
-- **defaults/main.yml:** Added `ubtu24cis_tmp_partition_mount_options` variable for tmp.mount systemd unit — addresses PR #163
+- tasks/prelim.yml: Fixed mount option gathering to preserve `/etc/fstab` source entries (UUID=, PARTUUID=, LABEL=) instead of using volatile `/dev/sdX` device names from `mount` output — addresses #162, thank you @samicemalone
+- defaults/main.yml: Added commented `sntrup761x25519-sha512` post-quantum KEX algorithm option — addresses #156, thank you @cagriersen
+- templates/tmp.mount.j2: Fixed systemd mount unit syntax `Options:` → `Options=` — addresses PR #163, thank you @kevingunn-wk
+- defaults/main.yml: Added `ubtu24cis_tmp_partition_mount_options` variable for tmp.mount systemd unit — addresses PR #163
 
 #### QA Results
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ---
 
-## Public Repository 📣
+## Public Repository
 
 ![Org Stars](https://img.shields.io/github/stars/ansible-lockdown?label=Org%20Stars&style=social)
 ![Stars](https://img.shields.io/github/stars/ansible-lockdown/UBUNTU24-CIS?label=Repo%20Stars&style=social)
@@ -17,13 +17,13 @@
 
 ![License](https://img.shields.io/github/license/ansible-lockdown/UBUNTU24-CIS?label=License)
 
-## Lint & Pre-Commit Tools 🔧
+## Lint & Pre-Commit Tools
 
 
 ![YamlLint](https://img.shields.io/badge/yamllint-Present-brightgreen?style=flat&logo=yaml&logoColor=white)
 ![Ansible-Lint](https://img.shields.io/badge/ansible--lint-Present-brightgreen?style=flat&logo=ansible&logoColor=white)
 
-## Community Release Information 📂
+## Community Release Information
 
 ![Release Branch](https://img.shields.io/badge/Release%20Branch-Main-brightgreen)
 ![Release Tag](https://img.shields.io/github/v/tag/ansible-lockdown/UBUNTU24-CIS?label=Release%20Tag&&color=success)
@@ -43,7 +43,7 @@
 
 ---
 
-## Subscriber Release Information 🔐
+## Subscriber Release Information
 
 ![Private Release Branch](https://img.shields.io/endpoint?url=https://ansible-lockdown.github.io/github_linux_IaC/badges/Private-UBUNTU24-CIS/release-branch.json)
 ![Private Benchmark Version](https://img.shields.io/endpoint?url=https://ansible-lockdown.github.io/github_linux_IaC/badges/Private-UBUNTU24-CIS/benchmark-version.json)
@@ -55,25 +55,25 @@
 
 ---
 
-## Looking for support? 🤝
+## Looking for support?
 
 [Lockdown Enterprise](https://www.lockdownenterprise.com#GH_AL_UBUNTU24_CIS)
 
 [Ansible support](https://www.mindpointgroup.com/cybersecurity-products/ansible-counselor#GH_AL_UBUNTU24_CIS)
 
-### Community 💬
+### Community
 
 On our [Discord Server](https://www.lockdownenterprise.com/discord) to ask questions, discuss features, or just chat with other Ansible-Lockdown users
 
 ---
 
-## 🚨 Caution(s) 🚨
+## Caution(s)
 
 This role **will make changes to the system** which may have unintended consequences. This is not an auditing tool but rather a remediation tool to be used after an audit has been conducted.
 
 - Testing is the most important thing you can do.
 
-- Check Mode is not guaranteed! 🚫 The role will complete in check mode without errors, but it is not supported and should be used with caution.
+- Check Mode is not guaranteed! The role will complete in check mode without errors, but it is not supported and should be used with caution.
 
 - This role was developed against a clean install of the Operating System. If you are implementing to an existing system please review this role for any site specific changes that are needed.
 
@@ -83,7 +83,7 @@ This role **will make changes to the system** which may have unintended conseque
 
 ---
 
-## Coming From A Previous Release ⏪
+## Coming From A Previous Release
 
 CIS release always contains changes, it is highly recommended to review the new references and available variables. This have changed significantly since ansible-lockdown initial release.
 This is now compatible with python3 if it is found to be the default interpreter. This does come with pre-requisites which it configures the system accordingly.
@@ -105,7 +105,7 @@ This is managed using tags:
 The control found in defaults main also need to reflect this as this control the testing that takes place if you are using the audit component.
 
 ---
-## Requirements ✅
+## Requirements
 
 **General:**
 
@@ -130,13 +130,13 @@ UBUNTU 24 - Other versions are not supported.
 
 ---
 
-## Auditing 🔍
+## Auditing
 
 This can be turned on or off within the defaults/main.yml file with the variable run_audit. The value is false by default, please refer to the wiki for more details. The defaults file also populates the goss checks to check only the controls that have been enabled in the ansible role.
 
 This is a much quicker, very lightweight, checking (where possible) config compliance and live/running settings.
 
-A new form of auditing has been developed, by using a small (12MB) go binary called [goss](https://github.com/goss-org/goss) along with the relevant configurations to check. Without the need for infrastructure or other tooling.
+A new form of auditing has been developed, by using a small (16MB) go binary called [goss](https://github.com/krameff/goss) along with the relevant configurations to check. Without the need for infrastructure or other tooling.
 This audit will not only check the config has the correct setting but aims to capture if it is running with that configuration also trying to remove [false positives](https://www.mindpointgroup.com/blog/is-compliance-scanning-still-relevant/) in the process.
 
 Refer to [UBUNTU24-CIS-Audit](https://github.com/ansible-lockdown/UBUNTU24-CIS-Audit).
@@ -148,11 +148,10 @@ Note: More tests are run during audit as we check config and running state.
 
 ```txt
 
-ok: [default] => {
+ok: [ubuntu2404] => {
     "msg": [
-        "msg": [
-        "The pre remediation audit results are: Count: 763, Failed: 234, Skipped: 4, Duration: 9.741s",
-        "The post remediation audit results are: Count: 763, Failed: 19, Skipped: 4, Duration: 12.725s",
+        "The pre remediation audit results are: Count: 778, Failed: 330, Skipped: 38, Duration: 3.609s",
+        "The post remediation audit results are: Count: 778, Failed: 26, Skipped: 5, Duration: 4.280s",
         "Full breakdown can be found in /opt",
         ""
     ]
@@ -162,7 +161,7 @@ PLAY RECAP *********************************************************************
 default                    : ok=270  changed=23   unreachable=0    failed=0    skipped=140  rescued=0    ignored=0
 ```
 
-## Documentation 📖
+## Documentation
 
 - [Read The Docs](https://ansible-lockdown.readthedocs.io/en/latest/)
 - [Getting Started](https://www.lockdownenterprise.com/docs/getting-started-with-lockdown#GH_AL_UBUNTU24_cis)
@@ -175,7 +174,7 @@ default                    : ok=270  changed=23   unreachable=0    failed=0    s
 
 This role is designed that the end user should not have to edit the tasks themselves. All customizing should be done via the defaults/main.yml file or with extra vars within the project, job, workflow, etc.
 
-## Tags 🏷️
+## Tags
 
 There are many tags available for added control precision. Each control has its own set of tags noting what level, what OS element it relates to, whether it's a patch or audit, and the rule number. Additionally, NIST references follow a specific conversion format for consistency and clarity.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,10 @@ ubtu24cis_section5: true
 ubtu24cis_section6: true
 ubtu24cis_section7: true
 
+# Run the OS validation check
+# Supported OSs will not need for this to be changed - see README
+os_check: true
+
 ## Reboot system before audit
 # System will reboot if false, can give better audit results
 skip_reboot: true
@@ -65,6 +69,14 @@ system_is_ec2: false
 # This allows the ability to skip tasks that may cause an issue
 ubtu24cis_uses_root: false
 
+# The shell can differ in OS or setups
+# Containers often may have a different shell also
+ubtu24cis_shell_executable: /bin/bash
+
+# A location that can be used as a temporary location to execute scripts
+# note the drive with need exec permissions used by 1.1.1.10
+ubtu24cis_temp_exec_location: /var
+
 # UID settings for interactive users
 # These are discovered via logins.def if set true
 discover_int_uid: false
@@ -84,7 +96,7 @@ max_int_uid: 65533
 
 ###########################################
 ### Goss is required on the remote host ###
-### vars/auditd.yml for other settings ###
+### vars/audit.yml for other settings ###
 
 # Allow audit to setup the requirements including installing git (if option chosen and downloading and adding goss binary to system)
 setup_audit: false
@@ -92,41 +104,11 @@ setup_audit: false
 # enable audits to run - this runs the audit and get the latest content
 run_audit: false
 # Run heavy tests - some tests can have more impact on a system enabling these can have greater impact on a system
-audit_run_heavy_tests: true
-# Ability to limit the number of concurrent processes used by goss (default 50)
-audit_max_concurrent: 50
-
+audit_run_heavy_tests: false
 ## Only run Audit do not remediate
 audit_only: false
 
 #############################
-
-# How to retrieve audit binary
-# Options are copy or download - detailed settings at the bottom of this file
-# you will need access to either github or the file already downloaded
-get_audit_binary_method: download
-
-## if get_audit_binary_method - copy the following needs to be updated for your environment
-## it is expected that it will be copied from somewhere accessible to the control node
-## e.g copy from ansible control node to remote host
-audit_bin_copy_location: /some/accessible/path
-
-# how to get audit files onto host options
-# options are git/copy/archive/get_url other e.g. if you wish to run from already downloaded conf
-audit_content: git
-
-# If using either archive, copy, get_url:
-## Note will work with .tar files - zip will require extra configuration
-### If using get_url this is expecting github url in tar.gz format e.g.
-### https://github.com/ansible-lockdown/UBUNTU24-CIS-Audit/archive/refs/heads/benchmark-v1.0.0.tar.gz
-audit_conf_source: "some path or url to copy from"
-
-# Destination for the audit content to be placed on managed node
-# note may not need full path e.g. /opt with the directory being the {{ benchmark }}-Audit directory
-audit_conf_dest: "/opt"
-
-# Where the audit logs are stored
-audit_log_dir: '/opt'
 
 ## Ability to collect and take audit files moving to a centralized location
 # This enables the collection of the files from the host
@@ -598,6 +580,11 @@ ubtu24cis_ignore_apt_update_changed_when: false
 # mount point for the controls in section1.
 ubtu24cis_debug_mount_data: false
 
+## 1.1.1.10 Ability to remove temporary script after control has run
+# may cause issues with later testing if required for investigation etc
+
+ubtu24cis_remove_kernel_discovery_script: false
+
 ## Control 1.1.2.x
 # If set to `true`, rule will be implemented using the `tmp.mount` systemd-service,
 # otherwise fstab configuration will be used.
@@ -946,7 +933,7 @@ ubtu24cis_sshd_login_grace_time: 60
 # This variable sets the time interval in seconds between sending "keep-alive"
 # messages from the server to the client. These types of messages are intended to
 # keep the connection alive and prevent it being terminated due to inactivity.
-ubtu24cis_sshd_client_alive_interval: 300
+ubtu24cis_sshd_client_alive_interval: 15
 # This variable sets the maximum number of unresponsive "keep-alive" messages
 # that can be sent from the server to the client before the connection is considered
 # inactive and thus, closed.
@@ -1017,6 +1004,14 @@ ubtu24cis_sudo_package: "sudo"
 ubtu24cis_sudo_logfile: "/var/log/sudo.log"
 
 ## Control 5.2.4 sudoers NOPASSWD
+
+# Connecting user, due to the way many users work differently this is to try and assist the use of connecting user if required
+# This is useful when part of kickstart build or running as root and not defining the ansible_user option
+# used @ ubtu24 5.2.4
+ubtu24cis_default_user: root
+ubtu24cis_connecting_user: "{{ ansible_facts['env']['SUDO_USER'] | default(ubtu24cis_default_user) }}"
+ubtu24cis_playbook_user: "{{ ansible_user | default(ubtu24cis_connecting_user) }}"
+
 # The following variable specifies a list of users that should not be required to provide a password
 # for escalation. Feel free to edit it according to your needs.
 ubtu24cis_sudoers_exclude_nopasswd_list:
@@ -1308,8 +1303,8 @@ ubtu24cis_journald_runtimekeepfree: "#RuntimeKeepFree=50M"
 ubtu24cis_journald_maxfilesec: "#MaxFileSec=1month"
 
 ## Controls 6.1.2.x (`journald`) and 6.1.3.x (`rsyslog`)
-# This variable governs which logging system is used.
-# Available options for this variable are `rsyslog` or `journald`.
+# This variable governs which logging system are used.
+# Available options for this variable is `rsyslog` or `journald`.
 ubtu24cis_syslog_service: 'journald'
 
 ## Control 6.1.3.5 - Ensure rsyslog logging is configured
@@ -1337,6 +1332,11 @@ ubtu24cis_journal_servercertificatefile:
 # of certificate authorities (CAs) that the client trusts. These trusted certificates are used
 # to validate the authenticity of the remote server's certificate.
 ubtu24cis_journal_trustedcertificatefile:
+
+## Control 6.1.3.6 remote syslog server setup
+# uses ubtu24cis_remote_log_server a per journald 6.1.2.1.2
+ubtu24cis_remote_log_port: 514
+ubtu24cis_remote_log_protocol: tcp
 
 ## Control 6.1.3.8 - Ensure logrotate is configured
 # This variable enables the installation of logrotate, which is needed for the implementation of Control 6.1.3.8
@@ -1371,7 +1371,7 @@ ubtu24cis_priv_command_excluded_mounts: []
 # Buffering in memory is useful in situations, where the audit system is overwhelmed
 # with incoming audit events, and needs to temporarily store them until they can be processed.
 # This variable should be set to a sufficient value. The CIS baseline recommends at least `8192` as value.
-ubtu24cis_audit_back_log_limit: 8192
+ubtu24cis_auditd_back_log_limit: 8192
 
 ## Controls 6.2.2.x - What to do when log files fill up
 ## Control 6.2.2.1 - Ensure audit log storage size is configured
@@ -1383,7 +1383,7 @@ ubtu24cis_max_log_file_size: 10
 ## Control 6.2.2.2 - Ensure audit logs are not automatically deleted
 # This variable determines what action the audit system should take when the maximum
 # size of a log file is reached.
-# Available options for this variable are as follows:
+# Available options for this variable is as follows:
 # - `ignore`: the system does nothing when the size of a log file is full;
 # - `syslog`: a message is sent to the system log indicating the problem;
 # - `suspend`: the system suspends recording audit events until the log file is cleared or rotated;
@@ -1419,8 +1419,8 @@ ubtu24cis_auditd_disk_error_action: syslog
 
 ## Control 6.2.2.4 - Ensure system warns when audit logs are low on space
 # This variable tells the system what action to take when the system has detected
-# that it is starting to get low on disk space.
-# Available options for this variable are as follows:
+# that is starting to get low on disk space.
+# Available options for this variable is as follows:
 # "ignore" - the system does nothing when presented with the aforementioned issue;
 # "syslog" - a message is sent to the system log about disk space running low;
 # "email" - the system sends an email notification to the email address
@@ -1434,7 +1434,7 @@ ubtu24cis_auditd_disk_error_action: syslog
 ubtu24cis_auditd_space_left_action: email
 # This variable tells the system what action to take when the system has detected
 # that it is low on disk space.
-# Available options for this variable are as follows:
+# Available options for this variable is as follows:
 # "ignore" - the system does nothing when presented with the aforementioned issue;
 # "syslog" - a message is sent to the system log about disk space running low;
 # "email" - the system sends an email notification to the email address
@@ -1583,7 +1583,10 @@ ubtu24cis_ownership_adjust: true
 ubtu24cis_suid_sgid_adjust: false
 
 ## Control 7.2.10 - Ensure local interactive user dot files access is configured
-# This variable is a toggle foe enabling/disabling the automated modification of
+# This variable is a toggle for enabling/disabling the automated modification of
 # permissions on dot files.
 # Possible values are `true` and `false`.
 ubtu24cis_dotperm_ansiblemanaged: true
+
+# This variable allows to exclude only necessary files (i.e. ['.xinitrc'])
+ubtu24cis_dotfile_exclusions: []

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,33 +1,8 @@
 ---
 
-- name: "Adding options for /tmp"
-  when: not ubtu24cis_tmp_svc
-  vars:
-    mount_point: '/tmp'
-  ansible.posix.mount:
-    path: "{{ mount_point }}"
-    src: "{{ prelim_mount_point_fs_and_options[mount_point]['src'] }}"
-    state: present
-    fstype: "{{ prelim_mount_point_fs_and_options[mount_point]['fs_type'] }}"
-    opts: "{{ prelim_mount_point_fs_and_options[mount_point]['options'] | unique | join(',') }}"
-  listen: "Remount /tmp"
-
-- name: "Remounting /tmp"
-  vars:
-    mount_point: '/tmp'
-  ansible.posix.mount:
-    path: "{{ mount_point }}"
-    state: remounted
-  listen: "Remount /tmp"
-
-- name: "Remounting /tmp systemd"
-  when: ubtu24cis_tmp_svc
-  vars:
-    mount_point: '/tmp'
-  ansible.builtin.systemd:
-    name: tmp.mount
-    state: restarted
-    daemon_reload: true
+- name: "Remount tmp filesystem"
+  ansible.builtin.import_tasks:
+    file: remount_tmp.yml
   listen: "Remount /tmp"
 
 - name: "Adding options for /dev/shm"
@@ -144,11 +119,6 @@
     state: remounted
   listen: "Remount /var/log/audit"
 
-- name: Update_Initramfs
-  ansible.builtin.command: update-initramfs -u
-  changed_when: true
-  notify: Set_reboot_required
-
 - name: Grub update
   ansible.builtin.command: update-grub
   changed_when: true
@@ -179,6 +149,12 @@
     name: "{{ ubtu24cis_syslog_service }}"
     state: restarted
 
+- name: Grub update
+  ansible.builtin.command: update-grub
+  changed_when: true
+  failed_when: false
+  notify: Set_reboot_required
+
 - name: Restart journald
   ansible.builtin.systemd:
     name: systemd-journald
@@ -190,7 +166,7 @@
     state: restarted
 
 - name: Flush ipv4 route table
-  when: ansible_facts.virtualization_type != "docker"
+  when: ansible_facts['virtualization_type'] != "docker"
   ansible.posix.sysctl:
     name: net.ipv4.route.flush
     value: '1'
@@ -198,7 +174,7 @@
 
 - name: Flush ipv6 route table
   when:
-    - ansible_facts.virtualization_type != "docker"
+    - ansible_facts['virtualization_type'] != "docker"
     - ubtu24cis_ipv6_required
   ansible.posix.sysctl:
     name: net.ipv6.route.flush
@@ -208,14 +184,6 @@
 - name: Reload ufw
   community.general.ufw:
     state: reloaded
-
-- name: Iptables persistent
-  ansible.builtin.command: bash -c "iptables-save > /etc/iptables/rules.v4"
-  changed_when: true
-
-- name: Ip6tables persistent
-  ansible.builtin.command: bash -c "ip6tables-save > /etc/iptables/rules.v6"
-  changed_when: true
 
 - name: Pam_auth_update_pwunix
   ansible.builtin.command: pam-auth-update --enable {{ ubtu24cis_pam_pwunix_file }}
@@ -237,31 +205,43 @@
   ansible.builtin.command: pam-auth-update --enable {{ ubtu24cis_pam_pwhistory_file }}
   changed_when: true
 
+- name: Iptables persistent
+  ansible.builtin.command: bash -c "iptables-save > /etc/iptables/rules.v4"
+  changed_when: true
+
+- name: Ip6tables persistent
+  ansible.builtin.command: bash -c "ip6tables-save > /etc/iptables/rules.v6"
+  changed_when: true
+
 - name: Auditd rules reload
-  when: discovered_augenrules_check.stdout is search('No change') or prelim_auditd_immutable_check.rc == 1
+  when: discovered_augenrules_check.stdout is search('No change') or discovered_auditd_immutable_check.rc == 1
   ansible.builtin.command: augenrules --load
   changed_when: true
   failed_when: discovered_augenrule_load.rc not in [ 0, 1 ]
   register: discovered_augenrule_load
+  listen: Update auditd
 
 - name: Audit_immutable_fact
   when:
     - discovered_audit_rules_updated.changed
-    - auditd_immutable_check is defined
+    - discovered_auditd_immutable_check is defined
   ansible.builtin.debug:
     msg: "Reboot required for auditd to apply new rules as immutable set"
   notify: Set_reboot_required
+  listen: Update auditd
 
 - name: Stop auditd process
+  when: discovered_auditd_immutable_check.rc == 1
   ansible.builtin.command: systemctl kill auditd
   changed_when: true
-  listen: Restart auditd
+  listen: Update auditd
 
 - name: Start auditd process
+  when: discovered_auditd_immutable_check.rc == 1
   ansible.builtin.systemd:
     name: auditd
     state: started
-  listen: Restart auditd
+  listen: Update auditd
 
 - name: Restart sshd
   ansible.builtin.systemd:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - jammy
+        - noble
   galaxy_tags:
     - system
     - security

--- a/tasks/LE_audit_setup.yml
+++ b/tasks/LE_audit_setup.yml
@@ -3,12 +3,12 @@
 - name: Pre Audit Setup | Set audit package name
   block:
     - name: Pre Audit Setup | Set audit package name | 64bit
-      when: ansible_facts.machine == "x86_64"
+      when: ansible_facts['machine'] == "x86_64"
       ansible.builtin.set_fact:
         audit_pkg_arch_name: AMD64
 
     - name: Pre Audit Setup | Set audit package name | ARM64
-      when: (ansible_facts.machine == "arm64" or ansible_facts.machine == "aarch64")
+      when: (ansible_facts['machine'] == "arm64" or ansible_facts['machine'] == "aarch64")
       ansible.builtin.set_fact:
         audit_pkg_arch_name: ARM64
 
@@ -21,6 +21,10 @@
     group: root
     checksum: "{{ audit_bin_version[audit_pkg_arch_name + '_checksum'] }}"
     mode: 'u+x,go-w'
+    validate_certs: "{{ audit_bin_validate_certs }}"
+    url_username: "{{ audit_bin_url_username | default(omit) }}"
+    url_password: "{{ audit_bin_url_password | default(omit) }}"
+  no_log: true
 
 - name: Pre Audit Setup | Copy audit binary
   when: get_audit_binary_method == 'copy'

--- a/tasks/auditd.yml
+++ b/tasks/auditd.yml
@@ -8,7 +8,7 @@
     set -o pipefail
     ausyscall --dump |  awk  '{print $2}'
   args:
-    executable: /bin/bash
+    executable: "{{ ubtu24cis_shell_executable }}"
   changed_when: false
   failed_when: discovered_auditd_syscalls.rc not in [ 0, 1 ]
   check_mode: false
@@ -16,14 +16,31 @@
 
 - name: "POST | AUDITD | Ensure use of privileged commands is collected"
   ansible.builtin.shell: |
-    {%- set egrep_exclude = "(asdfmnop|{{ ubtu24cis_priv_command_excluded_mounts | join('|') }})" -%}
-    for i in $(df | grep '^/dev' | grep -Ev '{{ egrep_exclude }}' | awk '{ print $NF }'); do
-      find $i -xdev -type f -perm /6000 2>/dev/null;
+    set -o pipefail
+    for i in $(df | grep '^/dev' | grep -Ev '{{ exclude_options }}' | awk '{ print $NF }');
+    do find $i -xdev -type f -perm /6000 2>/dev/null;
     done
+  args:
+    executable: "{{ ubtu24cis_shell_executable }}"
   changed_when: false
   failed_when: discovered_privileged_commands.rc not in [0, 1]
   check_mode: false
   register: discovered_privileged_commands
+  vars:
+    exclude_options: "(asdfmnop|{{ ubtu24cis_priv_command_excluded_mounts | join('|') }})"
+
+- name: "POST | AUDIT | Check if auditd is immutable before changes"
+  when: "'auditd' in ansible_facts['packages']"
+  tags: always
+  ansible.builtin.shell: |
+    set -o pipefail
+    auditctl -s | grep "enabled 2"
+  args:
+    executable: "{{ ubtu24cis_shell_executable }}"
+  changed_when: false
+  failed_when: discovered_auditd_immutable_check.rc not in [ 0, 1 ]
+  check_mode: false
+  register: discovered_auditd_immutable_check
 
 - name: "POST | AUDITD | Apply auditd template for section 6.2.4.x"
   when: update_audit_template
@@ -36,11 +53,7 @@
     group: root
     mode: 'u-x,go-wx'
   register: discovered_audit_rules_updated
-  notify:
-    - Auditd rules reload
-    - Audit_immutable_fact
-    - Restart auditd
-    - Set_reboot_required
+  notify: Update auditd
 
 - name: POST | AUDITD | Set up auditd user logging exceptions
   when: ubtu24cis_allow_auditd_uid_user_exclusions
@@ -50,7 +63,7 @@
     owner: root
     group: root
     mode: 'u-x,go-rwx'
-  notify: Restart auditd
+  notify: Update auditd
 
 - name: POST | AUDITD | Flush handlers
   ansible.builtin.meta: flush_handlers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,11 +2,12 @@
 
 - name: Check OS version and family
   when:
-    - ansible_facts.distribution == 'Ubuntu'
-    - ansible_facts.distribution_major_version is version_compare('24', '!=')
+    - os_check
+    - ansible_facts['distribution'] == 'Ubuntu'
+    - ansible_facts['distribution_major_version'] is version_compare('24', '!=')
   tags: always
   ansible.builtin.fail:
-    msg: "This role can only be run against Ubuntu 24. {{ ansible_facts.distribution }} {{ ansible_facts.distribution_major_version }} is not supported."
+    msg: "This role can only be run against Ubuntu 24. {{ ansible_facts['distribution'] }} {{ ansible_facts['distribution_major_version'] }} is not supported."
 
 - name: Check ansible version
   tags: always
@@ -16,31 +17,49 @@
     success_msg: "This role is running a supported version of ansible {{ ansible_version.full }} >= {{ min_ansible_version }}"
 
 #  This control should always run as this can pass on unintended issues.
-- name: "Check password set for connecting user"
+- name: "Check password set for {{ ubtu24cis_playbook_user }} | password state"  # noqa name[template]
   when:
+    - ubtu24cis_playbook_user != 'root'
     - ubtu24cis_rule_5_2_4
-    - ansible_env.SUDO_USER is defined
+    - ansible_facts['env']['SUDO_USER'] is defined
+    - not system_is_ec2
   tags: always
   no_log: true
+  vars:
+    sudo_password_rule: ubtu24cis_rule_5_2_4  # pragma: allowlist secret
   block:
-    - name: "Capture current password state of connecting user"
+    - name: "Check password set for {{ ubtu24cis_playbook_user }} | password state"  # noqa name[template]
       ansible.builtin.shell: |
-        set -o pipefail
-        grep -w {{ ansible_env.SUDO_USER }} /etc/shadow | awk -F: '{print $2}'
-      args:
-        executable: /bin/bash
+          set -o pipefail
+          (grep {{ ubtu24cis_playbook_user }} /etc/shadow || echo 'not found:not found') | awk -F: '{print $2}'
       changed_when: false
-      failed_when: prelim_ansible_user_password_set.rc not in [0, 1]
+      failed_when: false
       check_mode: false
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
       register: prelim_ansible_user_password_set
 
-    - name: "Assert that password set for {{ ansible_env.SUDO_USER }} and account not locked"  # noqa name[template]
-      ansible.builtin.assert:
-        that: prelim_ansible_user_password_set.stdout != "!!" and prelim_ansible_user_password_set.stdout | length > 10
-        fail_msg: "You have {{ sudo_password_rule }} enabled but the user = {{ ansible_env.SUDO_USER }} has no password set - It can break access"
-        success_msg: "You have a password set for sudo user {{ ansible_env.SUDO_USER }}"
-      vars:
-        sudo_password_rule: ubtu24cis_rule_5_2_4  # pragma: allowlist secret
+    - name: "Check for local account {{ ubtu24cis_playbook_user }} | Check for local account"  # noqa name[template]
+      when: prelim_ansible_user_password_set.stdout == "not found"
+      ansible.builtin.debug:
+        msg: "No local account found for {{ ubtu24cis_playbook_user }} user. Skipping local account checks."
+
+    - name: "Check local account"
+      block:
+        - name: "Check password set for {{ ubtu24cis_playbook_user }} | Assert local password set"  # noqa name[template]
+          ansible.builtin.assert:
+            that:
+              - prelim_ansible_user_password_set.stdout | length != 0
+              - prelim_ansible_user_password_set.stdout != "!!"
+            fail_msg: "You have {{ sudo_password_rule }} enabled but the user = {{ ubtu24cis_playbook_user }} has no password set - It can break access"
+            success_msg: "You have a password set for the {{ ubtu24cis_playbook_user }} user"
+
+        - name: "Check account is not locked for {{ ubtu24cis_playbook_user }} | Assert local account not locked"  # noqa name[template]
+          when: prelim_ansible_user_password_set.stdout != "not found"
+          ansible.builtin.assert:
+            that: not prelim_ansible_user_password_set.stdout.startswith("!")
+            fail_msg: "You have {{ sudo_password_rule }} enabled but the user = {{ ubtu24cis_playbook_user }} is locked - It can break access"
+            success_msg: "The local account is not locked for {{ ubtu24cis_playbook_user }} user"
 
 - name: Ensure root password is set
   when:
@@ -53,7 +72,7 @@
         set -o pipefail
         LC_ALL=C passwd -S root | grep -E "(Password set, SHA512 crypt|root P |root L |Password locked)"
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: prelim_root_passwd_set.rc not in [0, 1]
       check_mode: false
@@ -77,8 +96,8 @@
 - name: Setup rules if container
   when:
     - ansible_connection in ['docker', 'community.docker.docker'] or
-      (ansible_facts.virtualization_type is defined and
-       ansible_facts.virtualization_type in ["docker", "lxc", "openvz", "podman", "container"])
+      (ansible_facts['virtualization_type'] is defined and
+       ansible_facts['virtualization_type'] in ["docker", "lxc", "openvz", "podman", "container"])
   tags: always
   block:
     - name: Discover and set container variable if required

--- a/tasks/post_remediation_audit.yml
+++ b/tasks/post_remediation_audit.yml
@@ -1,8 +1,13 @@
 ---
 
 - name: Post Audit | Run post_remediation {{ benchmark }} audit  # noqa name[template]
-  ansible.builtin.shell: "umask 0022 && {{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -f {{ audit_format }} -m {{ audit_max_concurrent }} -o {{ post_audit_outfile }} -g \"{{ group_names }}\""  # noqa yaml[line-length]
+  ansible.builtin.shell: |
+    set -o pipefail
+    umask 0022
+    {{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -f {{ audit_format }} -m {{ audit_max_concurrent }} -o {{ post_audit_outfile }} -g "{{ group_names }}"  # noqa yaml[line-length]
   changed_when: true
+  args:
+    executable: "{{ ubtu24cis_shell_executable }}"
   environment:
     AUDIT_BIN: "{{ audit_bin }}"
     AUDIT_CONTENT_LOCATION: "{{ audit_conf_dest | default('/opt') }}"
@@ -14,11 +19,10 @@
     - name: Post Audit | Capture audit data if json format
       ansible.builtin.shell: |
         set -o pipefail
-        grep -E '"summary-line.*Count:.*Failed' "{{ post_audit_outfile }}" | cut -d'"' -f4
-      args:
-        executable: /bin/bash
+        grep -E 'summary-line.*Count:.*Failed' "{{ post_audit_outfile }}" | cut -d'"' -f4
       changed_when: false
-      check_mode: false
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
       register: post_audit_summary_json
 
     - name: Post Audit | Set Fact for audit summary
@@ -32,10 +36,9 @@
       ansible.builtin.shell: |
         set -o pipefail
         tail -2 "{{ post_audit_outfile }}"  | tac | tr '\n' ' '
-      args:
-        executable: /bin/bash
       changed_when: false
-      check_mode: false
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
       register: post_audit_summary_documentation
 
     - name: Post Audit | Set Fact for audit summary

--- a/tasks/pre_remediation_audit.yml
+++ b/tasks/pre_remediation_audit.yml
@@ -17,9 +17,8 @@
   block:
     - name: Pre Audit Setup | Install git
       ansible.builtin.package:
-        name: git
+        name: git-core
         state: present
-        lock_timeout: "{{ ubtu24cis_apt_lock_timeout }}"
 
     - name: Pre Audit Setup | Retrieve audit content files from git
       ansible.builtin.git:
@@ -68,13 +67,18 @@
     - goss_template
     - run_audit
   ansible.builtin.template:
-    src: ansible_vars_goss.yml.j2
+    src: lockdown_audit.yml.j2
     dest: "{{ audit_vars_path }}"
     mode: 'go-rwx'
 
 - name: Pre Audit | Run pre_remediation audit {{ benchmark }}  # noqa name[template]
-  ansible.builtin.shell: "umask 0022 && {{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -f {{ audit_format }} -m {{ audit_max_concurrent }} -o {{ pre_audit_outfile }} -g \"{{ group_names }}\"" # noqa yaml[line-length]
+  ansible.builtin.shell: |
+    set -o pipefail
+    umask 0022
+    {{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -f {{ audit_format }} -m {{ audit_max_concurrent }} -o {{ pre_audit_outfile }} -g "{{ group_names }}"  # noqa yaml[line-length]
   changed_when: true
+  args:
+    executable: "{{ ubtu24cis_shell_executable }}"
   environment:
     AUDIT_BIN: "{{ audit_bin }}"
     AUDIT_CONTENT_LOCATION: "{{ audit_conf_dest | default('/opt') }}"
@@ -86,11 +90,10 @@
     - name: Pre Audit | Capture audit data if json format
       ansible.builtin.shell: |
         set -o pipefail
-        grep -E '\"summary-line.*Count:.*Failed' "{{ pre_audit_outfile }}" | cut -d'"' -f4
-      args:
-        executable: /bin/bash
+        grep -E 'summary-line.*Count:.*Failed' "{{ pre_audit_outfile }}" | cut -d'"' -f4
       changed_when: false
-      check_mode: false
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
       register: pre_audit_summary_json
 
     - name: Pre Audit | Set Fact for audit summary
@@ -103,11 +106,10 @@
     - name: Pre Audit | Capture audit data if documentation format
       ansible.builtin.shell: |
         set -o pipefail
-        tail -2 "{{ pre_audit_outfile }}"  | tac | tr '\n' ' '
-      args:
-        executable: /bin/bash
+        tail -2 "{{ pre_audit_outfile }}" | tac | tr '\n' ' '
       changed_when: false
-      check_mode: false
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
       register: pre_audit_summary_documentation
 
     - name: Pre Audit | Set Fact for audit summary

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -1,48 +1,43 @@
 ---
 
-- name: "PRELIM | AUDIT | Set default values for facts"
-  ansible.builtin.set_fact:
-    control_1_6_1_4_was_run: false
-    ubtu24cis_apparmor_enforce_only: false
-  changed_when: false
-
-- name: "PRELIM | AUDIT | squashfs logic"
-  when: ubtu24cis_rule_1_1_1_7
+- name: "PRELIM | PATCH | Run apt update"
   tags: always
-  block:
-    - name: "PRELIM | AUDIT | Register if snap being used"
-      ansible.builtin.shell: |
-        set -o pipefail
-        lsblk | grep -wc "/snap"
-      args:
-        executable: /bin/bash
-      changed_when: false
-      failed_when: prelim_snap_pkg_mgr.rc not in [ 0, 1 ]
-      check_mode: false
-      register: prelim_snap_pkg_mgr
+  ansible.builtin.package:
+    update_cache: true
+    cache_valid_time: 3600
+    lock_timeout: "{{ ubtu24cis_apt_lock_timeout }}"
+  changed_when: not ubtu24cis_ignore_apt_update_changed_when
 
-    - name: "PRELIM | AUDIT | Register if squashfs is built into the kernel"
-      ansible.builtin.shell: |
-        set -o pipefail
-        cat /lib/modules/$(uname -r)/modules.builtin | grep "squashfs"
-      args:
-        executable: /bin/bash
-      changed_when: false
-      failed_when: prelim_squashfs_builtin.rc not in [ 0, 1 ]
-      check_mode: false
-      register: prelim_squashfs_builtin
+- name: Include audit specific variables
+  when: run_audit or audit_only or setup_audit
+  tags:
+    - setup_audit
+    - run_audit
+  ansible.builtin.include_vars:
+    file: audit.yml
+
+- name: Include pre-remediation audit tasks
+  when: run_audit or audit_only or setup_audit
+  tags:
+    - run_audit or audit_only
+    - setup_audit
+  ansible.builtin.import_tasks:
+    file: pre_remediation_audit.yml
 
 - name: PRELIM | AUDIT | Section 1.1 | Create list of mount points
   tags: always
   ansible.builtin.set_fact:
-    prelim_mount_names: "{{ ansible_facts.mounts | map(attribute='mount') | list }}"
+    prelim_mount_names: "{{ ansible_facts['mounts'] | map(attribute='mount') | list }}"
 
 - name: PRELIM | AUDIT | Section 1.1 | Retrieve mount options
   tags: always
   block:
     - name: PRELIM | AUDIT | Section 1.1 | Retrieve mount options - call mount # noqa command-instead-of-module
       ansible.builtin.shell: |
+        set -o pipefail
         mount | awk '{print $1, $3, $5, $6}'
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       check_mode: false
       register: prelim_mount_output
@@ -52,7 +47,7 @@
         set -o pipefail
         awk '$0 !~ /^[[:space:]]*#/ && NF >= 2 {print $1, $2}' /etc/fstab
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       check_mode: false
       register: prelim_fstab_sources
@@ -80,78 +75,6 @@
       ansible.builtin.debug:
         msg: "{{ prelim_mount_point_fs_and_options }}"
 
-- name: "PRELIM | PATCH | Run apt update"
-  tags: always
-  ansible.builtin.package:
-    cache_valid_time: 3600
-    lock_timeout: "{{ ubtu24cis_apt_lock_timeout }}"
-  changed_when: not ubtu24cis_ignore_apt_update_changed_when
-
-- name: Include audit specific variables
-  when: run_audit or audit_only or setup_audit
-  tags:
-    - setup_audit
-    - run_audit
-  ansible.builtin.include_vars:
-    file: audit.yml
-
-- name: Include pre-remediation audit tasks
-  when: run_audit or audit_only or setup_audit
-  tags:
-    - run_audit or audit_only
-    - setup_audit
-  ansible.builtin.import_tasks:
-    file: pre_remediation_audit.yml
-
-- name: "PRELIM | AUDIT | Wireless adapter pre-requisites"
-  when:
-    - ubtu24cis_rule_3_1_2
-    - not system_is_container
-  tags: always
-  block:
-    - name: "PRELIM | AUDIT | Discover is wireless adapter on system"
-      ansible.builtin.command: find /sys/class/net/*/ -type d -name wireless
-      changed_when: false
-      failed_when: prelim_wireless_adapters.rc not in [ 0, 1 ]
-      check_mode: false
-      register: prelim_wireless_adapters
-
-    - name: "PRELIM | AUDIT | If wireless adapter present capture module"
-      when: prelim_wireless_adapters.rc == 0
-      ansible.builtin.shell: |
-        for driverdir in $(find /sys/class/net/*/ -type d -name wireless | xargs -0 dirname);
-          do basename "$(readlink -f "$driverdir"/device/driver/module)";
-        done | sort -u
-      changed_when: false
-      failed_when: prelim_wireless_modules.rc not in [ 0, 1 ]
-      check_mode: false
-      register: prelim_wireless_modules
-
-- name: "PRELIM | PATCH | Find all sudoers files."
-  when: ubtu24cis_rule_5_2_4 or ubtu24cis_rule_5_2_5
-  tags: always
-  ansible.builtin.shell: "find /etc/sudoers /etc/sudoers.d/ -type f ! -name '*~' ! -name '*.*'"
-  changed_when: false
-  failed_when: prelim_sudoers_files.rc not in [0, 1]
-  check_mode: false
-  register: prelim_sudoers_files
-
-- name: "PRELIM | PATCH | Ensure conf.d directory exists required for 5.3.3.2.x"
-  when:
-    - ubtu24cis_rule_5_3_3_2_1 or
-      ubtu24cis_rule_5_3_3_2_2 or
-      ubtu24cis_rule_5_3_3_2_3 or
-      ubtu24cis_rule_5_3_3_2_4 or
-      ubtu24cis_rule_5_3_3_2_5 or
-      ubtu24cis_rule_5_3_3_2_6
-  tags: always
-  ansible.builtin.file:
-    path: '/etc/security/pwquality.conf.d'
-    state: directory
-    owner: root
-    group: root
-    mode: 'u+x,g-w,o-rwx'
-
 - name: "PRELIM | AUDIT | Discover Interactive UID MIN and MIN from logins.def"
   when: not discover_int_uid
   tags: always
@@ -161,7 +84,7 @@
         set -o pipefail
         grep -w "^UID_MIN" /etc/login.defs | awk '{print $NF}'
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       check_mode: false
       register: prelim_uid_min_id
@@ -171,7 +94,7 @@
         set -o pipefail
         grep -w "^UID_MAX" /etc/login.defs | awk '{print $NF}'
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       check_mode: false
       register: prelim_uid_max_id
@@ -181,7 +104,7 @@
         set -o pipefail
         grep -w "^GID_MIN" /etc/login.defs | awk '{print $NF}'
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       check_mode: false
       register: prelim_gid_min_id
@@ -192,127 +115,10 @@
         max_int_uid: "{{ prelim_uid_max_id.stdout }}"
         min_int_gid: "{{ prelim_gid_min_id.stdout }}"
 
-- name: "PRELIM | AUDIT | Capture pam configs related files"
-  tags: always
-  ansible.builtin.find:
-    paths:
-      - '/usr/share/pam-configs/'
-      - '/etc/pam.d/'
-  register: prelim_pam_conf_files
-
-- name: "PRELIM | AUDIT | Capture pam security related files"
-  tags: always
-  ansible.builtin.find:
-    paths:
-      - /etc/security/pwquality.conf.d/
-    patterns: '*.conf'
-  register: prelim_pam_pwquality_confs
-
-- name: "PRELIM | AUDIT | Interactive Users"
-  tags: always
-  ansible.builtin.shell: >
-    grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '(!index($7, "sbin/nologin") && $7 != "/bin/nologin" && $7 != "/bin/false" && $7 != "/dev/null") { print $1 }'
-  changed_when: false
-  check_mode: false
-  register: prelim_interactive_usernames
-
-- name: "PRELIM | AUDIT | Interactive User accounts home directories"
-  tags: always
-  ansible.builtin.shell: >
-    grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '(!index($7, "sbin/nologin") && $7 != "/bin/nologin" && $7 != "/bin/false" && $7 != "/dev/null") { print $6 }'
-  changed_when: false
-  check_mode: false
-  register: prelim_interactive_users_home
-
-- name: "PRELIM | AUDIT | Interactive UIDs"
-  tags: always
-  ansible.builtin.shell: >
-    grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '(!index($7, "sbin/nologin") && $7 != "/bin/nologin" && $7 != "/bin/false") { print $3 }'
-  changed_when: false
-  check_mode: false
-  register: prelim_interactive_uids
-
-- name: "PRELIM | AUDIT | Gather UID 0 accounts other than root"
-  when: ubtu24cis_rule_5_4_2_1
-  tags: always
-  ansible.builtin.shell: |
-    set -o pipefail
-    cat /etc/passwd | awk -F: '($3 == 0 && $1 != "root") {i++;print $1 } END {exit i}'
-  args:
-    executable: /bin/bash
-  changed_when: false
-  check_mode: false
-  register: prelim_uid_zero_accounts_except_root
-
-- name: "PRELIM | PATCH | Create journald conf.d directory"
-  when:
-    - ubtu24cis_rule_6_1_2_2 or
-      ubtu24cis_rule_6_1_2_3 or
-      ubtu24cis_rule_6_1_2_4
-  tags: always
-  ansible.builtin.file:
-    path: /etc/systemd/journald.conf.d
-    state: directory
-    owner: root
-    group: root
-    mode: 'u+x,go-w'
-
-- name: "PRELIM | PATCH | Ensure auditd is installed"
-  when:
-    - ubtu24cis_rule_6_2_1_1 or
-      ubtu24cis_rule_6_2_4_1 or
-      ubtu24cis_rule_6_2_4_6 or
-      ubtu24cis_rule_6_2_4_8
-  tags: always
-  block:
-    - name: "PRELIM | PATCH | Ensure auditd is installed"
-      ansible.builtin.package:
-        name: ['auditd', 'audispd-plugins']
-        state: present
-        lock_timeout: "{{ ubtu24cis_apt_lock_timeout }}"
-
-    - name: "PRELIM | AUDIT | Audit conf and rules files | list files"
-      ansible.builtin.find:
-        path: /etc/audit/
-        file_type: file
-        recurse: true
-        patterns: '*.conf,*.rules'
-      register: prelim_auditd_conf_files
-
-- name: "PRELIM | AUDIT | Check if auditd is immutable before changes"
-  when: "'auditd' in ansible_facts.packages"
-  tags: always
-  ansible.builtin.shell: |
-    set -o pipefail
-    auditctl -s | grep "enabled 2"
-  args:
-    executable: /bin/bash
-  changed_when: false
-  failed_when: prelim_auditd_immutable_check.rc not in [ 0, 1 ]
-  check_mode: false
-  register: prelim_auditd_immutable_check
-
-- name: "PRELIM | AUDIT | 6.2.4.x | Capture information about auditd logfile path | discover file"
-  when:
-    - ubtu24cis_rule_6_2_4_1 or
-      ubtu24cis_rule_6_2_4_2 or
-      ubtu24cis_rule_6_2_4_3 or
-      ubtu24cis_rule_6_2_4_4
-  tags: always
-  ansible.builtin.shell: |
-    set -o pipefail
-    grep ^log_file /etc/audit/auditd.conf | awk '{ print $NF }'
-  args:
-    executable: /bin/bash
-  changed_when: false
-  check_mode: false
-  failed_when: prelim_auditd_logfile.rc not in [ 0, 1 ]
-  register: prelim_auditd_logfile
-
 - name: "PRELIM | PATCH | Install ACL"
   when:
     - ubtu24cis_rule_7_2_9
-    - "'acl' not in ansible_facts.packages"
+    - "'acl' not in ansible_facts['packages']"
   tags: always
   ansible.builtin.package:
     name: acl
@@ -327,29 +133,7 @@
     state: present
     lock_timeout: "{{ ubtu24cis_apt_lock_timeout }}"
 
-- name: "PRELIM | PATCH | Install UFW"
-  when:
-    - ubtu24cis_rule_4_2_1
-    - ubtu24cis_section4
-    - ubtu24cis_firewall_package == "ufw"
-  tags: always
-  ansible.builtin.package:
-    name: ufw
-    state: present
-    lock_timeout: "{{ ubtu24cis_apt_lock_timeout }}"
-
 ## Optional
-
-- name: "OPTIONAL | PATCH | UFW firewall force to use /etc/sysctl.conf settings"
-  when:
-    - ubtu24cis_firewall_package == "ufw"
-    - ubtu24cis_ufw_use_sysctl
-  tags: always
-  ansible.builtin.lineinfile:
-    path: /etc/default/ufw
-    regexp: ^IPT_SYSCTL=.*
-    line: IPT_SYSCTL=/etc/sysctl.conf
-    mode: 'u-x,go-wx'
 
 - name: "OPTIONAL | PATCH | Install Logrotate if missing"
   when:

--- a/tasks/remount_tmp.yml
+++ b/tasks/remount_tmp.yml
@@ -1,0 +1,51 @@
+---
+
+- name: "Configure and remount /tmp with appropriate options | not systemd tmp.mount"
+  when: not ubtu24cis_tmp_svc
+  vars:
+    mount_point: '/tmp'
+  block:
+    - name: "Add filesystem options for /tmp"
+      ansible.posix.mount:
+        path: "{{ mount_point }}"
+        src: "{{ prelim_mount_point_fs_and_options[mount_point]['src'] }}"
+        state: present
+        fstype: "{{ prelim_mount_point_fs_and_options[mount_point]['fs_type'] }}"
+        opts: "{{ prelim_mount_point_fs_and_options[mount_point]['options'] | unique | join(',') }}"
+
+    - name: "Remounting /tmp"
+      ansible.posix.mount:
+        path: "{{ mount_point }}"
+        state: remounted
+      failed_when: false
+      register: discovered_remount_tmp
+
+- name: "Reloading /tmp systemd service"
+  when: ubtu24cis_tmp_svc
+  vars:
+    mount_point: '/tmp'
+  ansible.builtin.systemd:
+    name: tmp.mount
+    state: reloaded
+    daemon_reload: true
+  failed_when: false
+  register: discovered_remount_tmp_systemd
+  listen: "Remount /tmp"
+
+- name: "/tmp mount busy, set reboot required fact"
+  when: (discovered_remount_tmp is defined and discovered_remount_tmp.failed | default(false)) or
+        (discovered_remount_tmp_systemd is defined and discovered_remount_tmp_systemd.failed | default(false))
+  block:
+    - name: Set reboot required fact
+      ansible.builtin.set_fact:
+        change_requires_reboot: true
+
+    - name: "/tmp mount busy, reboot required to apply changes | Warning"
+      ansible.builtin.debug:
+        msg: "Warning: /tmp mount busy, reboot required to apply changes"
+
+    - name: "/tmp mount busy, reboot required to apply changes"
+      ansible.builtin.import_tasks:
+        file: warning_facts.yml
+      vars:
+        warn_control_id: "/tmp mount busy, reboot required"

--- a/tasks/section_1/cis_1.1.1.x.yml
+++ b/tasks/section_1/cis_1.1.1.x.yml
@@ -179,30 +179,28 @@
     - name: "1.1.1.6 | PATCH | Ensure overlayfs kernel module is not available | Edit modprobe config"
       ansible.builtin.lineinfile:
         path: /etc/modprobe.d/CIS.conf
-        regexp: "^(#)?install overlayfs(\\s|$)"
-        line: "install overlayfs /bin/true"
+        regexp: "^(#)?install overlay(\\s|$)"
+        line: "install overlay /bin/true"
         create: true
         mode: 'go-rwx'
 
     - name: "1.1.1.6 | PATCH | Ensure overlayfs kernel module is not available | blacklist"
       ansible.builtin.lineinfile:
         path: /etc/modprobe.d/blacklist.conf
-        regexp: "^(#)?blacklist overlayfs(\\s|$)"
-        line: "blacklist overlayfs"
+        regexp: "^(#)?blacklist overlay(\\s|$)"
+        line: "blacklist overlay"
         create: true
         mode: 'go-rwx'
 
     - name: "1.1.1.6 | PATCH | Ensure overlayfs kernel module is not available | Disable overlayfs"
       when: not system_is_container
       community.general.modprobe:
-        name: overlayfs
+        name: overlay
         state: absent
 
 - name: "1.1.1.7 | PATCH | Ensure squashfs kernel module is not available"
   when:
     - ubtu24cis_rule_1_1_1_7
-    - prelim_squashfs_builtin.rc != 0
-    - prelim_snap_pkg_mgr.rc == 1
   tags:
     - level2-server
     - level2-workstation
@@ -212,27 +210,54 @@
     - squashfs
     - NIST800-53R5_CM-7
   block:
-    - name: "1.1.1.7 | PATCH | Ensure squashfs kernel module is not available | Edit modprobe config"
-      ansible.builtin.lineinfile:
-        path: /etc/modprobe.d/CIS.conf
-        regexp: "^(#)?install squashfs(\\s|$)"
-        line: "install squashfs /bin/true"
-        create: true
-        mode: 'go-rwx'
+    - name: "1.1.1.7 | PATCH | Ensure squashfs kernel module is not available | Register if snap being used"
+      ansible.builtin.shell: |
+        set -o pipefail
+        lsblk | grep -wc "/snap"
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
+      changed_when: false
+      failed_when: discovered_snap_pkg_mgr.rc not in [ 0, 1 ]
+      check_mode: false
+      register: discovered_snap_pkg_mgr
 
-    - name: "1.1.1.7 | PATCH | Ensure squashfs kernel module is not available | blacklist"
-      ansible.builtin.lineinfile:
-        path: /etc/modprobe.d/blacklist.conf
-        regexp: "^(#)?blacklist squashfs(\\s|$)"
-        line: "blacklist squashfs"
-        create: true
-        mode: 'go-rwx'
+    - name: "1.1.1.7 | PATCH | Ensure squashfs kernel module is not available | Register if squashfs is built into the kernel"
+      ansible.builtin.shell: |
+        set -o pipefail
+        cat /lib/modules/$(uname -r)/modules.builtin | grep "squashfs"
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
+      changed_when: false
+      failed_when: discovered_squashfs_builtin.rc not in [ 0, 1 ]
+      check_mode: false
+      register: discovered_squashfs_builtin
 
-    - name: "1.1.1.7 | PATCH | Ensure squashfs kernel module is not available | Disable squashfs"
-      when: not system_is_container
-      community.general.modprobe:
-        name: squashfs
-        state: absent
+    - name: "1.1.1.7 | PATCH | Ensure squashfs kernel module is not available | If not using snap"
+      when:
+        - discovered_squashfs_builtin.rc != 0
+        - discovered_snap_pkg_mgr.rc == 1
+      block:
+        - name: "1.1.1.7 | PATCH | Ensure squashfs kernel module is not available | Edit modprobe config"
+          ansible.builtin.lineinfile:
+            path: /etc/modprobe.d/CIS.conf
+            regexp: "^(#)?install squashfs(\\s|$)"
+            line: "install squashfs /bin/true"
+            create: true
+            mode: 'go-rwx'
+
+        - name: "1.1.1.7 | PATCH | Ensure squashfs kernel module is not available | blacklist"
+          ansible.builtin.lineinfile:
+            path: /etc/modprobe.d/blacklist.conf
+            regexp: "^(#)?blacklist squashfs(\\s|$)"
+            line: "blacklist squashfs"
+            create: true
+            mode: 'go-rwx'
+
+        - name: "1.1.1.7 | PATCH | Ensure squashfs kernel module is not available | Disable squashfs"
+          when: not system_is_container
+          community.general.modprobe:
+            name: squashfs
+            state: absent
 
 - name: "1.1.1.8 | PATCH | Ensure udf kernel module is not available"
   when: ubtu24cis_rule_1_1_1_8
@@ -305,7 +330,7 @@
   tags:
     - level1-server
     - level1-workstation
-    - patch
+    - audit
     - rule_1.1.1.10
     - filesystems
   vars:
@@ -314,13 +339,13 @@
     - name: "1.1.1.10 | PATCH | Ensure unused filesystems kernel modules are not available | Add discovery script"
       ansible.builtin.template:
         src: fs_with_cves.sh.j2
-        dest: /var/fs_with_cves.sh
+        dest: "{{ ubtu24cis_temp_exec_location }}/fs_with_cves.sh"
         owner: root
         group: root
         mode: 'u+x,go-wx'
 
     - name: "1.1.1.10 | AUDIT | Ensure unused filesystems kernel modules are not available | Run discovery script"
-      ansible.builtin.command: /var/fs_with_cves.sh
+      ansible.builtin.command: "{{ ubtu24cis_temp_exec_location }}/fs_with_cves.sh"
       changed_when: false
       failed_when: discovered_fs_modules_loaded.rc not in [ 0, 99 ]
       check_mode: false
@@ -333,7 +358,13 @@
           "Warning!! Discovered loaded Filesystem modules that need attention. This is a manual task
           {{ discovered_fs_modules_loaded.stdout_lines }}"
 
-    - name: "1.1.1.9 | AUDIT | Ensure usb-storage kernel module is not available | Capture Warning"
+    - name: "1.1.1.10 | AUDIT | Ensure unused filesystems kernel modules are not available | Capture Warning"
       when: discovered_fs_modules_loaded.stdout | length > 0
       ansible.builtin.import_tasks:
         file: warning_facts.yml
+
+    - name: "1.1.1.10 | AUDIT | Ensure unused filesystems kernel modules are not available | Remove discovery script"
+      when: ubtu24cis_remove_kernel_discovery_script
+      ansible.builtin.file:
+        path: "{{ ubtu24cis_temp_exec_location }}/fs_with_cves.sh"
+        state: absent

--- a/tasks/section_1/cis_1.1.2.1.x.yml
+++ b/tasks/section_1/cis_1.1.2.1.x.yml
@@ -1,9 +1,7 @@
 ---
 
-- name: "1.1.2.1.1 | PATCH | Ensure /tmp is a separate partition"
-  when:
-    - required_mount not in prelim_mount_names
-    - ubtu24cis_rule_1_1_2_1_1
+- name: "1.1.2.1.1 | AUDIT | Ensure /tmp is a separate partition"
+  when: ubtu24cis_rule_1_1_2_1_1
   tags:
     - level1-server
     - level1-workstation

--- a/tasks/section_1/cis_1.1.2.2.x.yml
+++ b/tasks/section_1/cis_1.1.2.2.x.yml
@@ -1,9 +1,7 @@
 ---
 
-- name: "1.1.2.2.1 | PATCH | Ensure /dev/shm is a separate partition"
-  when:
-    - ubtu24cis_rule_1_1_2_2_1
-    - required_mount not in prelim_mount_names
+- name: "1.1.2.2.1 | AUDIT  | Ensure /dev/shm is a separate partition"
+  when: ubtu24cis_rule_1_1_2_2_1
   tags:
     - level1-server
     - level1-workstation

--- a/tasks/section_1/cis_1.1.2.3.x.yml
+++ b/tasks/section_1/cis_1.1.2.3.x.yml
@@ -1,8 +1,6 @@
 ---
-- name: "1.1.2.3.1 | PATCH | Ensure separate partition exists for /home"
-  when:
-    - ubtu24cis_rule_1_1_2_3_1
-    - required_mount not in prelim_mount_names
+- name: "1.1.2.3.1 | AUDIT | Ensure separate partition exists for /home"
+  when: ubtu24cis_rule_1_1_2_3_1
   tags:
     - level1-server
     - level1-workstation

--- a/tasks/section_1/cis_1.1.2.4.x.yml
+++ b/tasks/section_1/cis_1.1.2.4.x.yml
@@ -1,9 +1,7 @@
 ---
 
-- name: "1.1.2.4.1 | PATCH | Ensure separate partition exists for /var"
-  when:
-    - ubtu24cis_rule_1_1_2_4_1
-    - required_mount not in prelim_mount_names
+- name: "1.1.2.4.1 | AUDIT | Ensure separate partition exists for /var"
+  when: ubtu24cis_rule_1_1_2_4_1
   tags:
     - level1-server
     - level1-workstation

--- a/tasks/section_1/cis_1.1.2.5.x.yml
+++ b/tasks/section_1/cis_1.1.2.5.x.yml
@@ -1,9 +1,7 @@
 ---
 
-- name: "1.1.2.5.1 | PATCH | Ensure separate partition exists for /var/tmp"
-  when:
-    - ubtu24cis_rule_1_1_2_5_1
-    - required_mount not in prelim_mount_names
+- name: "1.1.2.5.1 | AUDIT | Ensure separate partition exists for /var/tmp"
+  when: ubtu24cis_rule_1_1_2_5_1
   tags:
     - level1-server
     - level1-workstation

--- a/tasks/section_1/cis_1.1.2.6.x.yml
+++ b/tasks/section_1/cis_1.1.2.6.x.yml
@@ -1,9 +1,7 @@
 ---
 
-- name: "1.1.2.6.1 | PATCH | Ensure separate partition exists for /var/log"
-  when:
-    - ubtu24cis_rule_1_1_2_6_1
-    - required_mount not in prelim_mount_names
+- name: "1.1.2.6.1 | AUDIT | Ensure separate partition exists for /var/log"
+  when: ubtu24cis_rule_1_1_2_6_1
   tags:
     - level1-server
     - level1-workstation

--- a/tasks/section_1/cis_1.1.2.7.x.yml
+++ b/tasks/section_1/cis_1.1.2.7.x.yml
@@ -1,9 +1,7 @@
 ---
 
-- name: "1.1.2.7.1 | PATCH | Ensure separate partition exists for /var/log/audit"
-  when:
-    - ubtu24cis_rule_1_1_2_7_1
-    - required_mount not in prelim_mount_names
+- name: "1.1.2.7.1 | AUDIT  | Ensure separate partition exists for /var/log/audit"
+  when: ubtu24cis_rule_1_1_2_7_1
   tags:
     - level1-server
     - level1-workstation

--- a/tasks/section_1/cis_1.2.2.x.yml
+++ b/tasks/section_1/cis_1.2.2.x.yml
@@ -5,7 +5,7 @@
   tags:
     - level1-server
     - level1-workstation
-    - patch
+    - audit
     - rule_1.2.2.1
     - NIST800-53R5_SI-2
     - patch

--- a/tasks/section_1/cis_1.3.1.x.yml
+++ b/tasks/section_1/cis_1.3.1.x.yml
@@ -3,7 +3,7 @@
 - name: "1.3.1.1 | PATCH | Ensure AppArmor is installed"
   when:
     - ubtu24cis_rule_1_3_1_1
-    - "'apparmor' not in ansible_facts.packages or 'apparmor-utils' not in ansible_facts.packages"
+    - "'apparmor' not in ansible_facts['packages'] or 'apparmor-utils' not in ansible_facts['packages']"
   tags:
     - level1-server
     - level1-workstation
@@ -31,7 +31,7 @@
         set -o pipefail
         grep "GRUB_CMDLINE_LINUX=" /etc/default/grub | cut -f2 -d'"'
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_grub_cmdline_settings.rc not in [0, 1]
       check_mode: false
@@ -109,14 +109,14 @@
         set -o pipefail
         apparmor_status | grep "profiles are in enforce mode" | tr -d -c 0-9
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_apparmor_profilepre_count.rc not in [0, 1]
       check_mode: false
       register: discovered_apparmor_profilepre_count
 
     - name: "1.3.1.4 | PATCH | Ensure all AppArmor Profiles are enforcing | Apply enforcing to /etc/apparmor.d profiles"
-      ansible.builtin.shell: aa-enforce /etc/apparmor.d/*
+      ansible.builtin.command: aa-enforce /etc/apparmor.d/*
       changed_when: false
       failed_when: discovered_apparmor_profilepre_count.rc not in [0, 1]
 
@@ -125,7 +125,7 @@
         set -o pipefail
         apparmor_status | grep "profiles are in enforce mode" | tr -d -c 0-9
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_apparmor_profilepost_count.rc not in [0, 1]
       check_mode: false
@@ -167,14 +167,14 @@
         set -o pipefail
         apparmor_status | grep "profiles are in {{ ubtu24cis_apparmor_mode }} mode" | tr -d -c 0-9
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_apparmor_profile_pre_count.rc not in [0, 1]
       check_mode: false
       register: discovered_apparmor_profile_pre_count
 
     - name: "1.3.1.3 | PATCH | Ensure all AppArmor Profiles are in enforce or complain mode | Apply complaining/enforcing to /etc/apparmor.d profiles"
-      ansible.builtin.shell: aa-{{ ubtu24cis_apparmor_mode }} /etc/apparmor.d/*
+      ansible.builtin.command: aa-{{ ubtu24cis_apparmor_mode }} /etc/apparmor.d/*
       changed_when: false
       failed_when: discovered_apparmor_profile_pre_count.rc not in [0, 1]
 
@@ -183,7 +183,7 @@
         set -o pipefail
         apparmor_status | grep "profiles are in {{ ubtu24cis_apparmor_mode }} mode" | tr -d -c 0-9
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_apparmor_profile_post_count.rc not in [0, 1]
       check_mode: false

--- a/tasks/section_1/cis_1.4.x.yml
+++ b/tasks/section_1/cis_1.4.x.yml
@@ -18,7 +18,7 @@
         dest: "{{ ubtu24cis_grub_user_file }}"
         owner: root
         group: root
-        mode: 'go-w'
+        mode: 'u=rwx,go=rx'
       notify: Grub update
 
     - name: "1.4.1 | PATCH | Ensure bootloader password is set | allow unrestricted boot"

--- a/tasks/section_1/cis_1.5.x.yml
+++ b/tasks/section_1/cis_1.5.x.yml
@@ -94,7 +94,7 @@
 - name: "1.5.4 | PATCH | Ensure prelink is not installed"
   when:
     - ubtu24cis_rule_1_5_4
-    - "'prelink' in ansible_facts.packages"
+    - "'prelink' in ansible_facts['packages']"
   tags:
     - level1-server
     - level1-workstation
@@ -138,7 +138,7 @@
         mode: 'go-r'
 
     - name: "1.5.5 | PATCH | Ensure Automatic Error Reporting is not enabled | remove package"
-      when: "'apport' in ansible_facts.packages"
+      when: "'apport' in ansible_facts['packages']"
       ansible.builtin.package:
         name: apport
         state: absent

--- a/tasks/section_1/cis_1.7.x.yml
+++ b/tasks/section_1/cis_1.7.x.yml
@@ -5,7 +5,7 @@
     - ubtu24cis_rule_1_7_1
     - not ubtu24cis_desktop_required
     - ubtu24cis_disruption_high
-    - "'gdm3' in ansible_facts.packages"
+    - "'gdm3' in ansible_facts['packages']"
   tags:
     - level2-server
     - patch

--- a/tasks/section_1/main.yml
+++ b/tasks/section_1/main.yml
@@ -69,7 +69,7 @@
 
 - name: "SECTION | 1.7 | Configure DNOME Display Manager"
   when:
-    - "'gdm3' in ansible_facts.packages"
+    - "'gdm3' in ansible_facts['packages']"
     - not system_is_container
   ansible.builtin.import_tasks:
     file: cis_1.7.x.yml

--- a/tasks/section_2/cis_2.1.x.yml
+++ b/tasks/section_2/cis_2.1.x.yml
@@ -3,7 +3,7 @@
 - name: "2.1.1 | PATCH | Ensure autofs services are not in use"
   when:
     - ubtu24cis_rule_2_1_1
-    - "'autofs' in ansible_facts.packages"
+    - "'autofs' in ansible_facts['packages']"
   tags:
     - level1-server
     - level2-workstation
@@ -29,8 +29,8 @@
       notify: Systemd_daemon_reload
       ansible.builtin.systemd:
         name: autofs
-        enabled: "{{ ('autofs' in ansible_facts.packages) | ternary(false, omit) }}"
-        state: "{{ ('autofs' in ansible_facts.packages) | ternary('stopped', omit) }}"
+        enabled: "{{ ('autofs' in ansible_facts['packages']) | ternary(false, omit) }}"
+        state: "{{ ('autofs' in ansible_facts['packages']) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.2 | PATCH | Ensure avahi daemon services are not in use"
@@ -47,7 +47,7 @@
       when:
         - not ubtu24cis_avahi_server
         - not ubtu24cis_avahi_mask
-        - "'avahi-daemon' in ansible_facts.packages or 'avahi-autoipd' in ansible_facts.packages"
+        - "'avahi-daemon' in ansible_facts['packages'] or 'avahi-autoipd' in ansible_facts['packages']"
       ansible.builtin.package:
         name:
           - avahi-autoipd
@@ -63,8 +63,8 @@
       notify: Systemd_daemon_reload
       ansible.builtin.systemd:
         name: "{{ item }}"
-        enabled: "{{ ('avahi-daemon' in ansible_facts.packages) | ternary(false, omit) }}"
-        state: "{{ ('avahi-daemon' in ansible_facts.packages) | ternary('stopped', omit) }}"
+        enabled: "{{ ('avahi-daemon' in ansible_facts['packages']) | ternary(false, omit) }}"
+        state: "{{ ('avahi-daemon' in ansible_facts['packages']) | ternary('stopped', omit) }}"
         masked: true
       loop:
         - avahi-daemon.socket
@@ -86,7 +86,7 @@
       when:
         - not ubtu24cis_dhcp_server
         - not ubtu24cis_dhcp_mask
-        - "'isc-dhcp-server' in ansible_facts.packages"
+        - "'isc-dhcp-server' in ansible_facts['packages']"
       ansible.builtin.package:
         name: isc-dhcp-server
         state: absent
@@ -100,8 +100,8 @@
       notify: Systemd_daemon_reload
       ansible.builtin.systemd:
         name: "{{ item }}"
-        enabled: "{{ ('isc-dhcp-server' in ansible_facts.packages) | ternary(false, omit) }}"
-        state: "{{ ('isc-dhcp-server' in ansible_facts.packages) | ternary('stopped', omit) }}"
+        enabled: "{{ ('isc-dhcp-server' in ansible_facts['packages']) | ternary(false, omit) }}"
+        state: "{{ ('isc-dhcp-server' in ansible_facts['packages']) | ternary('stopped', omit) }}"
         masked: true
       loop:
         - isc-dhcp-server.service
@@ -121,7 +121,7 @@
   block:
     - name: "2.1.4 | PATCH | Ensure dns server services are not in use | Remove package"
       when:
-        - "'bind9' in ansible_facts.packages"
+        - "'bind9' in ansible_facts['packages']"
         - not ubtu24cis_dns_server
         - not ubtu24cis_dns_mask
       ansible.builtin.package:
@@ -137,8 +137,8 @@
       notify: Systemd_daemon_reload
       ansible.builtin.systemd:
         name: named.service
-        enabled: "{{ ('bind9' in ansible_facts.packages) | ternary(false, omit) }}"
-        state: "{{ ('bind9' in ansible_facts.packages) | ternary('stopped', omit) }}"
+        enabled: "{{ ('bind9' in ansible_facts['packages']) | ternary(false, omit) }}"
+        state: "{{ ('bind9' in ansible_facts['packages']) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.5 | PATCH | Ensure dnsmasq services are not in use"
@@ -153,7 +153,7 @@
   block:
     - name: "2.1.5 | PATCH | Ensure dnsmasq services are not in use | Remove package"
       when:
-        - "'dnsmasq' in ansible_facts.packages"
+        - "'dnsmasq' in ansible_facts['packages']"
         - not ubtu24cis_dnsmasq_server
         - not ubtu24cis_dnsmasq_mask
       ansible.builtin.package:
@@ -169,8 +169,8 @@
       notify: Systemd_daemon_reload
       ansible.builtin.systemd:
         name: dnsmasq.service
-        enabled: "{{ ('dnsmasq' in ansible_facts.packages) | ternary(false, omit) }}"
-        state: "{{ ('dnsmasq' in ansible_facts.packages) | ternary('stopped', omit) }}"
+        enabled: "{{ ('dnsmasq' in ansible_facts['packages']) | ternary(false, omit) }}"
+        state: "{{ ('dnsmasq' in ansible_facts['packages']) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.6 | PATCH | Ensure ftp server services are not in use"
@@ -186,7 +186,7 @@
   block:
     - name: "2.1.6 | PATCH | Ensure ftp server services are not in use | Remove package"
       when:
-        - "'vsftp' in ansible_facts.packages"
+        - "'vsftp' in ansible_facts['packages']"
         - not ubtu24cis_ftp_server
         - not ubtu24cis_ftp_mask
       ansible.builtin.package:
@@ -202,8 +202,8 @@
       notify: Systemd_daemon_reload
       ansible.builtin.systemd:
         name: vsftpd.service
-        enabled: "{{ ('vsftpd' in ansible_facts.packages) | ternary(false, omit) }}"
-        state: "{{ ('vsftpd' in ansible_facts.packages) | ternary('stopped', omit) }}"
+        enabled: "{{ ('vsftpd' in ansible_facts['packages']) | ternary(false, omit) }}"
+        state: "{{ ('vsftpd' in ansible_facts['packages']) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.7 | PATCH | Ensure ldap server services are not in use"
@@ -218,7 +218,7 @@
   block:
     - name: "2.1.7 | PATCH | Ensure ldap server services are not in use | Remove package"
       when:
-        - "'slapd' in ansible_facts.packages"
+        - "'slapd' in ansible_facts['packages']"
         - not ubtu24cis_ldap_server
         - not ubtu24cis_ldap_mask
       ansible.builtin.package:
@@ -234,8 +234,8 @@
       notify: Systemd_daemon_reload
       ansible.builtin.systemd:
         name: slapd.service
-        enabled: "{{ ('slapd' in ansible_facts.packages) | ternary(false, omit) }}"
-        state: "{{ ('slapd' in ansible_facts.packages) | ternary('stopped', omit) }}"
+        enabled: "{{ ('slapd' in ansible_facts['packages']) | ternary(false, omit) }}"
+        state: "{{ ('slapd' in ansible_facts['packages']) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.8 | PATCH | Ensure message access server services are not in use"
@@ -252,7 +252,7 @@
   block:
     - name: "2.1.8 | PATCH | Ensure message access server services are not in use | Remove package"
       when:
-        - "'dovecot-pop3d' in ansible_facts.packages or 'dovecot-imapd' in ansible_facts.packages"
+        - "'dovecot-pop3d' in ansible_facts['packages'] or 'dovecot-imapd' in ansible_facts['packages']"
         - not ubtu24cis_message_server
         - not ubtu24cis_message_mask
       ansible.builtin.package:
@@ -270,8 +270,8 @@
       notify: Systemd_daemon_reload
       ansible.builtin.systemd:
         name: "{{ item }}"
-        enabled: "{{ ('dovecot-imapd' in ansible_facts.packages) | ternary(false, omit) }}"
-        state: "{{ ('dovecot-imapd' in ansible_facts.packages) | ternary('stopped', omit) }}"
+        enabled: "{{ ('dovecot-imapd' in ansible_facts['packages']) | ternary(false, omit) }}"
+        state: "{{ ('dovecot-imapd' in ansible_facts['packages']) | ternary('stopped', omit) }}"
         masked: true
       loop:
         - "dovecot.socket"
@@ -293,7 +293,7 @@
   block:
     - name: "2.1.9 | PATCH | Ensure network file system services are not in use | Remove package"
       when:
-        - "'nfs-kernel-server' in ansible_facts.packages"
+        - "'nfs-kernel-server' in ansible_facts['packages']"
         - not ubtu24cis_nfs_server
         - not ubtu24cis_nfs_mask
       ansible.builtin.package:
@@ -309,8 +309,8 @@
       notify: Systemd_daemon_reload
       ansible.builtin.systemd:
         name: nfs-server.service
-        enabled: "{{ ('nfs-kernel-server' in ansible_facts.packages) | ternary(false, omit) }}"
-        state: "{{ ('nfs-kernel-server' in ansible_facts.packages) | ternary('stopped', omit) }}"
+        enabled: "{{ ('nfs-kernel-server' in ansible_facts['packages']) | ternary(false, omit) }}"
+        state: "{{ ('nfs-kernel-server' in ansible_facts['packages']) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.10 | PATCH | Ensure nis server services are not in use"
@@ -326,7 +326,7 @@
   block:
     - name: "2.1.10 | PATCH | Ensure nis server services are not in use | Remove package"
       when:
-        - "'ypserv' in ansible_facts.packages"
+        - "'ypserv' in ansible_facts['packages']"
         - not ubtu24cis_nis_server
         - not ubtu24cis_nis_mask
       ansible.builtin.package:
@@ -341,8 +341,8 @@
         - ubtu24cis_nis_mask
       ansible.builtin.systemd:
         name: ypserv.service
-        enabled: "{{ ('ypserv' in ansible_facts.packages) | ternary(false, omit) }}"
-        state: "{{ ('ypserv' in ansible_facts.packages) | ternary('stopped', omit) }}"
+        enabled: "{{ ('ypserv' in ansible_facts['packages']) | ternary(false, omit) }}"
+        state: "{{ ('ypserv' in ansible_facts['packages']) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.11 | PATCH | Ensure print server services are not in use"
@@ -356,7 +356,7 @@
   block:
     - name: "2.1.11 | PATCH | Ensure print server services are not in use | Remove package"
       when:
-        - "'cups' in ansible_facts.packages"
+        - "'cups' in ansible_facts['packages']"
         - not ubtu24cis_print_server
         - not ubtu24cis_print_mask
       ansible.builtin.package:
@@ -372,8 +372,8 @@
       notify: Systemd_daemon_reload
       ansible.builtin.systemd:
         name: "{{ item }}"
-        enabled: "{{ ('cups' in ansible_facts.packages) | ternary(false, omit) }}"
-        state: "{{ ('cups' in ansible_facts.packages) | ternary('stopped', omit) }}"
+        enabled: "{{ ('cups' in ansible_facts['packages']) | ternary(false, omit) }}"
+        state: "{{ ('cups' in ansible_facts['packages']) | ternary('stopped', omit) }}"
         masked: true
       loop:
         - "cups.socket"
@@ -394,7 +394,7 @@
   block:
     - name: "2.1.12 | PATCH | Ensure rpcbind services are not in use | Remove package"
       when:
-        - "'rpcbind' in ansible_facts.packages"
+        - "'rpcbind' in ansible_facts['packages']"
         - not ubtu24cis_rpc_server
         - not ubtu24cis_rpc_mask
       ansible.builtin.package:
@@ -410,8 +410,8 @@
       notify: Systemd_daemon_reload
       ansible.builtin.systemd:
         name: "{{ item }}"
-        enabled: "{{ ('rpcbind' in ansible_facts.packages) | ternary(false, omit) }}"
-        state: "{{ ('rpcbind' in ansible_facts.packages) | ternary('stopped', omit) }}"
+        enabled: "{{ ('rpcbind' in ansible_facts['packages']) | ternary(false, omit) }}"
+        state: "{{ ('rpcbind' in ansible_facts['packages']) | ternary('stopped', omit) }}"
         masked: true
       loop:
         - rpcbind.service
@@ -431,7 +431,7 @@
   block:
     - name: "2.1.13 | PATCH | Ensure rsync services are not in use | Remove package"
       when:
-        - "'rsync' in ansible_facts.packages"
+        - "'rsync' in ansible_facts['packages']"
         - not ubtu24cis_rsync_server
         - not ubtu24cis_rsync_mask
       ansible.builtin.package:
@@ -447,8 +447,8 @@
       notify: Systemd_daemon_reload
       ansible.builtin.systemd:
         name: rsync.service
-        enabled: "{{ ('rsync' in ansible_facts.packages) | ternary(false, omit) }}"
-        state: "{{ ('rsync' in ansible_facts.packages) | ternary('stopped', omit) }}"
+        enabled: "{{ ('rsync' in ansible_facts['packages']) | ternary(false, omit) }}"
+        state: "{{ ('rsync' in ansible_facts['packages']) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.14 | PATCH | Ensure samba file server services are not in use"
@@ -464,7 +464,7 @@
   block:
     - name: "2.1.14 | PATCH | Ensure samba file server services are not in use | Remove package"
       when:
-        - "'samba' in ansible_facts.packages"
+        - "'samba' in ansible_facts['packages']"
         - not ubtu24cis_samba_server
         - not ubtu24cis_samba_mask
       ansible.builtin.package:
@@ -480,8 +480,8 @@
       notify: Systemd_daemon_reload
       ansible.builtin.systemd:
         name: smbd.service
-        enabled: "{{ ('samba' in ansible_facts.packages) | ternary(false, omit) }}"
-        state: "{{ ('samba' in ansible_facts.packages) | ternary('stopped', omit) }}"
+        enabled: "{{ ('samba' in ansible_facts['packages']) | ternary(false, omit) }}"
+        state: "{{ ('samba' in ansible_facts['packages']) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.15 | PATCH | Ensure snmp services are not in use"
@@ -497,7 +497,7 @@
   block:
     - name: "2.1.15 | PATCH | Ensure snmp services are not in use | Remove package"
       when:
-        - "'snmpd' in ansible_facts.packages"
+        - "'snmpd' in ansible_facts['packages']"
         - not ubtu24cis_snmp_server
         - not ubtu24cis_snmp_mask
       ansible.builtin.package:
@@ -513,8 +513,8 @@
       notify: Systemd_daemon_reload
       ansible.builtin.systemd:
         name: snmpd.service
-        enabled: "{{ ('snmpd' in ansible_facts.packages) | ternary(false, omit) }}"
-        state: "{{ ('snmpd' in ansible_facts.packages) | ternary('stopped', omit) }}"
+        enabled: "{{ ('snmpd' in ansible_facts['packages']) | ternary(false, omit) }}"
+        state: "{{ ('snmpd' in ansible_facts['packages']) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.16 | PATCH | Ensure tftp server services are not in use"
@@ -529,7 +529,7 @@
   block:
     - name: "2.1.16 | PATCH | Ensure tftp server services are not in use | Remove package"
       when:
-        - "'tftpd-hpa' in ansible_facts.packages"
+        - "'tftpd-hpa' in ansible_facts['packages']"
         - not ubtu24cis_tftp_server
         - not ubtu24cis_tftp_mask
       ansible.builtin.package:
@@ -545,8 +545,8 @@
       notify: Systemd_daemon_reload
       ansible.builtin.systemd:
         name: tftpd-hpa.service
-        enabled: "{{ ('tftpd-hpa' in ansible_facts.packages) | ternary(false, omit) }}"
-        state: "{{ ('tftpd-hpa' in ansible_facts.packages) | ternary('stopped', omit) }}"
+        enabled: "{{ ('tftpd-hpa' in ansible_facts['packages']) | ternary(false, omit) }}"
+        state: "{{ ('tftpd-hpa' in ansible_facts['packages']) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.17 | PATCH | Ensure web proxy server services are not in use"
@@ -561,7 +561,7 @@
   block:
     - name: "2.1.17 | PATCH | Ensure web proxy server services are not in use | Remove package"
       when:
-        - "'squid' in ansible_facts.packages"
+        - "'squid' in ansible_facts['packages']"
         - not ubtu24cis_squid_server
         - not ubtu24cis_squid_mask
       ansible.builtin.package:
@@ -577,8 +577,8 @@
       notify: Systemd_daemon_reload
       ansible.builtin.systemd:
         name: squid.service
-        enabled: "{{ ('squid' in ansible_facts.packages) | ternary(false, omit) }}"
-        state: "{{ ('squid' in ansible_facts.packages) | ternary('stopped', omit) }}"
+        enabled: "{{ ('squid' in ansible_facts['packages']) | ternary(false, omit) }}"
+        state: "{{ ('squid' in ansible_facts['packages']) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.18 | PATCH | Ensure web server services are not in use"
@@ -597,7 +597,7 @@
       when:
         - not ubtu24cis_apache2_server
         - not ubtu24cis_apache2_mask
-        - "'apache2' in ansible_facts.packages"
+        - "'apache2' in ansible_facts['packages']"
       ansible.builtin.package:
         name: apache2
         state: absent
@@ -608,7 +608,7 @@
       when:
         - not ubtu24cis_nginx_server
         - not ubtu24cis_nginx_mask
-        - "'nginx' in ansible_facts.packages"
+        - "'nginx' in ansible_facts['packages']"
       ansible.builtin.package:
         name: nginx
         state: absent
@@ -619,12 +619,12 @@
       when:
         - not ubtu24cis_apache2_server
         - ubtu24cis_apache2_mask
-        - "'apache2' in ansible_facts.packages"
+        - "'apache2' in ansible_facts['packages']"
       notify: Systemd_daemon_reload
       ansible.builtin.systemd:
         name: "{{ item }}"
-        enabled: "{{ ('apache2' in ansible_facts.packages) | ternary(false, omit) }}"
-        state: "{{ ('apache2' in ansible_facts.packages) | ternary('stopped', omit) }}"
+        enabled: "{{ ('apache2' in ansible_facts['packages']) | ternary(false, omit) }}"
+        state: "{{ ('apache2' in ansible_facts['packages']) | ternary('stopped', omit) }}"
         masked: true
       loop:
         - apache2.service
@@ -636,12 +636,12 @@
       when:
         - not ubtu24cis_nginx_server
         - ubtu24cis_nginx_mask
-        - "'nginx' in ansible_facts.packages"
+        - "'nginx' in ansible_facts['packages']"
       notify: Systemd_daemon_reload
       ansible.builtin.systemd:
-        name: ngnix.service
-        enabled: "{{ ('nginx' in ansible_facts.packages) | ternary(false, omit) }}"
-        state: "{{ ('nginx' in ansible_facts.packages) | ternary('stopped', omit) }}"
+        name: nginx.service
+        enabled: "{{ ('nginx' in ansible_facts['packages']) | ternary(false, omit) }}"
+        state: "{{ ('nginx' in ansible_facts['packages']) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.19 | PATCH | Ensure xinetd services are not in use"
@@ -656,7 +656,7 @@
   block:
     - name: "2.1.19 | PATCH | Ensure xinetd services are not in use | Remove package"
       when:
-        - "'xinetd' in ansible_facts.packages"
+        - "'xinetd' in ansible_facts['packages']"
         - not ubtu24cis_xinetd_server
         - not ubtu24cis_xinetd_mask
       ansible.builtin.package:
@@ -672,14 +672,14 @@
       notify: Systemd_daemon_reload
       ansible.builtin.systemd:
         name: xinetd.service
-        enabled: "{{ ('xinetd' in ansible_facts.packages) | ternary(false, omit) }}"
-        state: "{{ ('xinetd' in ansible_facts.packages) | ternary('stopped', omit) }}"
+        enabled: "{{ ('xinetd' in ansible_facts['packages']) | ternary(false, omit) }}"
+        state: "{{ ('xinetd' in ansible_facts['packages']) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.20 | PATCH | Ensure X window server services are not in use"
   when:
     - not ubtu24cis_xwindow_server
-    - "'xserver-common' in ansible_facts.packages"
+    - "'xserver-common' in ansible_facts['packages']"
     - ubtu24cis_rule_2_1_20
   tags:
     - level2-server
@@ -708,7 +708,7 @@
     warn_control_id: '2.1.21'
   block:
     - name: "2.1.21 | PATCH | Ensure mail transfer agent is configured for local-only mode | Make changes if exim4 installed"
-      when: "'exim4' in ansible_facts.packages"
+      when: "'exim4' in ansible_facts['packages']"
       ansible.builtin.lineinfile:
         path: /etc/exim4/update-exim4.conf.conf
         regexp: "{{ item.regexp }}"
@@ -730,7 +730,7 @@
       notify: Restart exim4
 
     - name: "2.1.21 | PATCH | Ensure mail transfer agent is configured for local-only mode | Make changes if postfix is installed"
-      when: "'postfix' in ansible_facts.packages"
+      when: "'postfix' in ansible_facts['packages']"
       notify: Restart postfix
       ansible.builtin.lineinfile:
         path: /etc/postfix/main.cf
@@ -739,8 +739,8 @@
 
     - name: "2.1.21 | WARN | Ensure mail transfer agents are configured for local-only mode | Message out other main agents"
       when:
-        - "'exim4' not in ansible_facts.packages"
-        - "'postfix' not in ansible_facts.packages"
+        - "'exim4' not in ansible_facts['packages']"
+        - "'postfix' not in ansible_facts['packages']"
       ansible.builtin.debug:
         msg:
           - "Warning!! You are not using either exim4 or postfix, please ensure mail services set for local only mode"
@@ -748,8 +748,8 @@
 
     - name: "2.1.21 | WARN | Ensure mail transfer agents are configured for local-only mode | warn_count"
       when:
-        - "'exim4' not in ansible_facts.packages"
-        - "'postfix' not in ansible_facts.packages"
+        - "'exim4' not in ansible_facts['packages']"
+        - "'postfix' not in ansible_facts['packages']"
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 

--- a/tasks/section_2/cis_2.3.2.x.yml
+++ b/tasks/section_2/cis_2.3.2.x.yml
@@ -49,7 +49,7 @@
         enabled: true
 
     - name: "2.3.2.2 | PATCH | Ensure systemd-timesyncd is enabled and running | disable other time sources | chrony"
-      when: "'chrony' in ansible_facts.packages"
+      when: "'chrony' in ansible_facts['packages']"
       ansible.builtin.systemd:
         name: chrony
         state: stopped
@@ -57,7 +57,7 @@
         masked: true
 
     - name: "2.3.2.2 | PATCH | Ensure systemd-timesyncd is enabled and running | disable other time sources | ntp"
-      when: "'ntp' in ansible_facts.packages"
+      when: "'ntp' in ansible_facts['packages']"
       ansible.builtin.systemd:
         name: ntp
         state: stopped

--- a/tasks/section_3/cis_3.1.x.yml
+++ b/tasks/section_3/cis_3.1.x.yml
@@ -26,7 +26,7 @@
         set -o pipefail
         grep "GRUB_CMDLINE_LINUX=" /etc/default/grub | cut -f2 -d'"'
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_ipv6_grub_cmdline_settings.rc not in [0, 1]
       check_mode: false
@@ -60,36 +60,58 @@
 
 - name: "3.1.2 | PATCH | Ensure wireless interfaces are disabled"
   when:
-    - prelim_wireless_modules.stdout is defined
     - ubtu24cis_rule_3_1_2
+    - not system_is_container
   tags:
     - level1-server
     - patch
     - rule_3.1.2
     - NIST800-53R5_CM-7
     - wireless
-  vars:
-    warn_control_id: '3.1.2'
   block:
-    - name: "3.1.2 | PATCH | Ensure wireless interfaces are disabled | Create modprobe.d file"
-      ansible.builtin.lineinfile:
-        path: /etc/modprobe.d/{{ item }}.conf
-        regexp: '^(#)?install true(\\s|$)'
-        line: install {{ item }} true
-        create: true
-        mode: 'go-wx'
-      loop: "{{ prelim_wireless_modules.stdout_lines }}"
+    - name: "3.1.2 | AUDIT | Ensure wireless interfaces are disabled | Discover is wireless adapter on system"
+      ansible.builtin.command: find /sys/class/net/*/ -type d -name wireless
+      changed_when: false
+      failed_when: prelim_wireless_adapters.rc not in [ 0, 1 ]
+      check_mode: false
+      register: prelim_wireless_adapters
 
-    - name: "3.1.2 | PATCH | Ensure wireless interfaces are disabled | blacklist"
-      ansible.builtin.lineinfile:
-        path: /etc/modprobe.d/blacklist.conf
-        regexp: "^(#)?blacklist {{ item }}(\\s|$)"
-        line: "blacklist {{ item }}"
-        create: true
-        mode: 'go-rwx'
-      loop: "{{ prelim_wireless_modules.stdout_lines }}"
-      loop_control:
-        label: "{{ item }}"
+    - name: "3.1.2 | AUDIT | Ensure wireless interfaces are disabled | If wireless adapter present capture module"
+      when: prelim_wireless_adapters.rc == 0
+      ansible.builtin.shell: |
+        set -o pipefail
+        for driverdir in $(find /sys/class/net/*/ -type d -name wireless | xargs -0 dirname);
+          do basename "$(readlink -f "$driverdir"/device/driver/module)";
+        done | sort -u
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
+      changed_when: false
+      failed_when: discovered_wireless_modules.rc not in [ 0, 1 ]
+      check_mode: false
+      register: discovered_wireless_modules
+
+    - name: "3.1.2 | PATCH | Ensure wireless interfaces are disabled | if wireless adapter exist"
+      when: discovered_wireless_modules.stdout is defined
+      block:
+        - name: "3.1.2 | PATCH | Ensure wireless interfaces are disabled | Create modprobe.d file"
+          ansible.builtin.lineinfile:
+            path: /etc/modprobe.d/{{ item }}.conf
+            regexp: '^(#)?install true(\\s|$)'
+            line: install {{ item }} true
+            create: true
+            mode: 'go-wx'
+          loop: "{{ discovered_wireless_modules.stdout_lines }}"
+
+        - name: "3.1.2 | PATCH | Ensure wireless interfaces are disabled | blacklist"
+          ansible.builtin.lineinfile:
+            path: /etc/modprobe.d/blacklist.conf
+            regexp: "^(#)?blacklist {{ item }}(\\s|$)"
+            line: "blacklist {{ item }}"
+            create: true
+            mode: 'go-rwx'
+          loop: "{{ discovered_wireless_modules.stdout_lines }}"
+          loop_control:
+            label: "{{ item }}"
 
 - name: "3.1.3 | PATCH | Ensure bluetooth services are not in use"
   when: ubtu24cis_rule_3_1_3
@@ -118,6 +140,6 @@
       notify: Systemd_daemon_reload
       ansible.builtin.systemd:
         name: bluetooth.service
-        enabled: "{{ ('bluez' in ansible_facts.packages) | ternary(false, omit) }}"
-        state: "{{ ('bluez' in ansible_facts.packages) | ternary('stopped', omit) }}"
+        enabled: "{{ ('bluez' in ansible_facts['packages']) | ternary(false, omit) }}"
+        state: "{{ ('bluez' in ansible_facts['packages']) | ternary('stopped', omit) }}"
         masked: true

--- a/tasks/section_4/cis_4.1.1.yml
+++ b/tasks/section_4/cis_4.1.1.yml
@@ -16,7 +16,7 @@
         set -o pipefail
         dpkg-query -l | grep -Ec "^ii\s*ufw|^ii\s*iptables|^ii\s*nftables"
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_firewall_pkgs.rc not in [ 0, 1 ]
       check_mode: false
@@ -25,7 +25,10 @@
     - name: "4.1.1 | AUDIT | Ensure a single firewall configuration utility is in use | Check enabled"
       when: discovered_firewall_pkgs.stdout not in [ 0, 1 ]
       ansible.builtin.shell: |
+        set -o pipefail
         for svc in ufw nftables iptables; do if [ "$(systemctl is-enabled $svc | grep enabled &> /dev/null)" ]; then fw_enabled=$(( fw_enabled +1 )); fi; done; echo $fw_enabled
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       check_mode: false
       register: discovered_enabled_firewalls

--- a/tasks/section_4/cis_4.2.x.yml
+++ b/tasks/section_4/cis_4.2.x.yml
@@ -1,9 +1,7 @@
 ---
 
 - name: "4.2.1 | PATCH | Ensure ufw is installed"
-  when:
-    - ubtu24cis_rule_4_2_1
-    - "'ufw' not in ansible_facts.packages"
+  when: ubtu24cis_rule_4_2_1
   tags:
     - level1-server
     - level1-workstation
@@ -20,7 +18,7 @@
 - name: "4.2.2 | PATCH | Ensure iptables-persistent is not installed with ufw"
   when:
     - ubtu24cis_rule_4_2_2
-    - "'iptables-persistent' in ansible_facts.packages"
+    - "'iptables-persistent' in ansible_facts['packages']"
   tags:
     - level1-server
     - level1-workstation
@@ -103,7 +101,7 @@
   tags:
     - level1-server
     - level1-workstation
-    - patch
+    - audit
     - rule_4.2.5
     - NIST800-53R5_SC-7
     - ufw
@@ -185,4 +183,16 @@
     - routed
   loop_control:
     label: "{{ item }}"
+  notify: Reload ufw
+
+- name: "OPTIONAL | PATCH | UFW firewall force to use /etc/sysctl.conf settings"
+  when:
+    - ubtu24cis_firewall_package == "ufw"
+    - ubtu24cis_ufw_use_sysctl
+  tags: always
+  ansible.builtin.lineinfile:
+    path: /etc/default/ufw
+    regexp: ^IPT_SYSCTL=.*
+    line: IPT_SYSCTL=/etc/sysctl.conf
+    mode: 'u-x,go-wx'
   notify: Reload ufw

--- a/tasks/section_4/cis_4.4.2.x.yml
+++ b/tasks/section_4/cis_4.4.2.x.yml
@@ -97,7 +97,7 @@
   tags:
     - level1-server
     - level1-workstation
-    - patch
+    - audit
     - rule_4.4.2.3
     - NIST800-53R5_CA-9
     - NIST800-53R5_SC-7

--- a/tasks/section_4/cis_4.4.3.x.yml
+++ b/tasks/section_4/cis_4.4.3.x.yml
@@ -89,7 +89,7 @@
   tags:
     - level1-server
     - level1-workstation
-    - patch
+    - audit
     - rule_4.4.3.3
     - NIST800-53R5_CA-9
     - NIST800-53R5_SC-7
@@ -184,4 +184,4 @@
 #       - ubtu24cis_save_iptables_cis_rules
 #       - ubtu24cis_rule_4_4_1_1 or
 #         ubtu24cis_rule_4_4_1_2 or
-#         ubtu24cis_rule_4_4_1_3
+#         ubtu24cis_rule_4_4_1_3 or

--- a/tasks/section_5/cis_5.1.x.yml
+++ b/tasks/section_5/cis_5.1.x.yml
@@ -103,6 +103,15 @@
     - NIST800-53R5_MP-2
     - sshd
   block:
+
+    - name: "5.1.4 | PATCH | Ensure sshd access is configured |Ensure /run/sshd exists for sshd -t validation"
+      ansible.builtin.file:
+        path: /run/sshd
+        state: directory
+        owner: root
+        group: root
+        mode: 'u=rwx,g=rx'
+
     - name: "5.1.4 | PATCH | Ensure sshd access is configured | Add allowed users"
       when: "ubtu24cis_sshd_allow_users| default('') | length > 0 "
       ansible.builtin.lineinfile:
@@ -407,6 +416,8 @@
     path: /etc/ssh/sshd_config
     regexp: (?i)^(#?)\s*MaxStartups
     line: 'MaxStartups 10:30:60'
+    insertbefore: '^Match'
+    firstmatch: true
     validate: 'sshd -t -f %s'
   notify: Restart sshd
 

--- a/tasks/section_5/cis_5.2.x.yml
+++ b/tasks/section_5/cis_5.2.x.yml
@@ -1,5 +1,25 @@
 ---
 
+- name: "5.2.5/6 | AUDIT | Find all sudoers files."
+  when: ubtu24cis_rule_5_2_4 or ubtu24cis_rule_5_2_5
+  tags:
+    - level1-server
+    - level1-workstation
+    - patch
+    - sudo
+    - rule_5.2.5
+    - rule_5.2.6
+    - NIST800-53R5_AC-6
+  ansible.builtin.shell: |
+    set -o pipefail
+    find /etc/sudoers /etc/sudoers.d/ -type f ! -name '*~' ! -name '*.*'
+  args:
+    executable: "{{ ubtu24cis_shell_executable }}"
+  changed_when: false
+  failed_when: discovered_sudoers_files.rc not in [0, 1]
+  check_mode: false
+  register: discovered_sudoers_files
+
 - name: "5.2.1 | PATCH | Ensure sudo is installed"
   when: ubtu24cis_rule_5_2_1
   tags:
@@ -60,7 +80,7 @@
         set -o pipefail
         grep -Ei '(nopasswd)' /etc/sudoers /etc/sudoers.d/* | cut -d':' -f1
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       become: true
       changed_when: false
       failed_when: discovered_sudoers_nopasswd.rc not in [0, 1]
@@ -92,7 +112,7 @@
     regexp: '^([^#].*)!authenticate(.*)'
     replace: '\1authenticate\2'
     validate: '/usr/sbin/visudo -cf %s'
-  loop: "{{ prelim_sudoers_files.stdout_lines }}"
+  loop: "{{ discovered_sudoers_files.stdout_lines }}"
   loop_control:
     label: "{{ item }}"
 
@@ -111,7 +131,7 @@
         set -o pipefail
         grep -is 'timestamp_timeout' /etc/sudoers /etc/sudoers.d/* | cut -d":" -f1 | uniq | sort
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_ubtu24cis_ssh_timeout_files.rc not in [0, 1]
       check_mode: false

--- a/tasks/section_5/cis_5.3.2.x.yml
+++ b/tasks/section_5/cis_5.3.2.x.yml
@@ -14,13 +14,65 @@
     - NIST800-53R5_IA-5
     - pam_auth_update
     - pam_unix
-  ansible.builtin.template:
-    src: "{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwunix_file }}.j2"
-    dest: "/{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwunix_file }}"
-    owner: root
-    group: root
-    mode: 'u-x,go-rwx'
-  notify: Pam_auth_update_pwunix
+  block:
+    - name: "5.3.2.1 | AUDIT | Ensure pam_unix module is enabled | Check common-account for pam_unix.so"
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -P -- '\bpam_unix\.so\b' /etc/pam.d/common-account
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
+      register: discovered_pam_unix_account
+      changed_when: false
+      failed_when: discovered_pam_unix_account.rc not in [0, 1]
+
+    - name: "5.3.2.1 | AUDIT | Ensure pam_unix module is enabled | Check common-session for pam_unix.so"
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -P -- '\bpam_unix\.so\b' /etc/pam.d/common-session
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
+      register: discovered_pam_unix_session
+      changed_when: false
+      failed_when: discovered_pam_unix_session.rc not in [0, 1]
+
+    - name: "5.3.2.1 | AUDIT | Ensure pam_unix module is enabled | Check common-auth for pam_unix.so"
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -P -- '\bpam_unix\.so\b' /etc/pam.d/common-auth
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
+      register: discovered_pam_unix_auth
+      changed_when: false
+      failed_when: discovered_pam_unix_auth.rc not in [0, 1]
+
+    - name: "5.3.2.1 | AUDIT | Ensure pam_unix module is enabled | Check common-password for pam_unix.so"
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -P -- '\bpam_unix\.so\b' /etc/pam.d/common-password
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
+      register: discovered_pam_unix_password
+      changed_when: false
+      failed_when: discovered_pam_unix_password.rc not in [0, 1]
+
+    - name: "5.3.2.1 | PATCH | Ensure pam_unix module is enabled | Ensure template"
+      ansible.builtin.template:
+        src: "{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwunix_file }}.j2"
+        dest: "/{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwunix_file }}"
+        owner: root
+        group: root
+        mode: 'u-x,go-rwx'
+      notify: Pam_auth_update_pwunix
+
+    - name: "5.3.2.1 | PATCH | Ensure pam_unix module is enabled | Force pam-auth-update if pam_unix entries are missing"
+      when: (discovered_pam_unix_account.stdout | length == 0) or
+            (discovered_pam_unix_session.stdout | length == 0) or
+            (discovered_pam_unix_auth.stdout | length == 0) or
+            (discovered_pam_unix_password.stdout | length == 0)
+      changed_when: true
+      ansible.builtin.debug:
+        msg: "pam_unix.so is missing from at least one /etc/pam.d/common-* file; forcing pam-auth-update."
+      notify: Pam_auth_update_pwunix
 
 - name: "5.3.2.2 | PATCH | Ensure pam_faillock module is enabled"
   when:
@@ -36,20 +88,52 @@
     - NIST800-53R5_NA
     - pam_auth_update
     - pam_faillock
-  ansible.builtin.template:
-    src: "{{ ubtu24cis_pam_confd_dir }}{{ item }}.j2"
-    dest: "/{{ ubtu24cis_pam_confd_dir }}{{ item }}"
-    owner: root
-    group: root
-    mode: 'u-x,go-rwx'
-  loop:
-    - "{{ ubtu24cis_pam_faillock_file }}"
-    - "{{ ubtu24cis_pam_faillock_notify_file }}"
-  loop_control:
-    label: "{{ item }}"
-  notify:
-    - Pam_auth_update_pwfaillock
-    - Pam_auth_update_pwfaillock_notify
+  block:
+    - name: "5.3.2.2 | AUDIT | Ensure pam_faillock module is enabled | Check common-auth for pam_faillock.so"
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -P -- '\bpam_faillock\.so\b' /etc/pam.d/common-auth
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
+      register: discovered_pam_faillock_auth
+      changed_when: false
+      failed_when: discovered_pam_faillock_auth.rc not in [0, 1]
+
+    - name: "5.3.2.2 | AUDIT | Ensure pam_faillock module is enabled | Check common-account for pam_faillock.so"
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -P -- '\bpam_faillock\.so\b' /etc/pam.d/common-account
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
+      register: discovered_pam_faillock_account
+      changed_when: false
+      failed_when: discovered_pam_faillock_account.rc not in [0, 1]
+
+    - name: "5.3.2.2 | PATCH | Ensure pam_faillock module is enabled | Ensure templates"
+      ansible.builtin.template:
+        src: "{{ ubtu24cis_pam_confd_dir }}{{ item }}.j2"
+        dest: "/{{ ubtu24cis_pam_confd_dir }}{{ item }}"
+        owner: root
+        group: root
+        mode: 'u-x,go-rwx'
+      loop:
+        - "{{ ubtu24cis_pam_faillock_file }}"
+        - "{{ ubtu24cis_pam_faillock_notify_file }}"
+      loop_control:
+        label: "{{ item }}"
+      notify:
+        - Pam_auth_update_pwfaillock
+        - Pam_auth_update_pwfaillock_notify
+
+    - name: "5.3.2.2 | PATCH | Ensure pam_faillock module is enabled | Force pam-auth-update if pam_faillock entries are missing"
+      when: (discovered_pam_faillock_auth.stdout | length == 0) or
+            (discovered_pam_faillock_account.stdout | length == 0)
+      changed_when: true
+      ansible.builtin.debug:
+        msg: "pam_faillock.so is missing from /etc/pam.d/common-auth or common-account; forcing pam-auth-update."
+      notify:
+        - Pam_auth_update_pwfaillock
+        - Pam_auth_update_pwfaillock_notify
 
 - name: "5.3.2.3 | PATCH | Ensure pam_pwquality module is enabled"
   when:
@@ -64,13 +148,32 @@
     - NIST800-53R5_NA
     - pam_auth_update
     - pam_quality
-  ansible.builtin.template:
-    src: "{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwquality_file }}.j2"
-    dest: "/{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwquality_file }}"
-    owner: root
-    group: root
-    mode: 'u-x,go-rwx'
-  notify: Pam_auth_update_pwquality
+  block:
+    - name: "5.3.2.3 | AUDIT | Ensure pam_pwquality module is enabled | Check common-password for pam_pwquality.so"
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -P -- '\bpam_pwquality\.so\b' /etc/pam.d/common-password
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
+      register: discovered_pam_pwquality_password
+      changed_when: false
+      failed_when: discovered_pam_pwquality_password.rc not in [0, 1]
+
+    - name: "5.3.2.3 | PATCH | Ensure pam_pwquality module is enabled | Ensure template"
+      ansible.builtin.template:
+        src: "{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwquality_file }}.j2"
+        dest: "/{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwquality_file }}"
+        owner: root
+        group: root
+        mode: 'u-x,go-rwx'
+      notify: Pam_auth_update_pwquality
+
+    - name: "5.3.2.3 | PATCH | Ensure pam_pwquality module is enabled | Force pam-auth-update if pam_pwquality entries are missing"
+      when: discovered_pam_pwquality_password.stdout | length == 0
+      changed_when: true
+      ansible.builtin.debug:
+        msg: "pam_pwquality.so is missing from /etc/pam.d/common-password; forcing pam-auth-update."
+      notify: Pam_auth_update_pwquality
 
 - name: "5.3.2.4 | PATCH | Ensure pam_pwhistory module is enabled"
   when:
@@ -85,10 +188,29 @@
     - NIST800-53R5_NA
     - pam_auth_update
     - pam_history
-  ansible.builtin.template:
-    src: "{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwhistory_file }}.j2"
-    dest: "/{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwhistory_file }}"
-    owner: root
-    group: root
-    mode: 'u-x,go-rwx'
-  notify: Pam_auth_update_pwhistory
+  block:
+    - name: "5.3.2.4 | AUDIT | Ensure pam_pwhistory module is enabled | Check common-password for pam_pwhistory.so"
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -P -- '\bpam_pwhistory\.so\b' /etc/pam.d/common-password
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
+      register: discovered_pam_pwhistory_password
+      changed_when: false
+      failed_when: discovered_pam_pwhistory_password.rc not in [0, 1]
+
+    - name: "5.3.2.4 | PATCH | Ensure pam_pwhistory module is enabled | Ensure template"
+      ansible.builtin.template:
+        src: "{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwhistory_file }}.j2"
+        dest: "/{{ ubtu24cis_pam_confd_dir }}{{ ubtu24cis_pam_pwhistory_file }}"
+        owner: root
+        group: root
+        mode: 'u-x,go-rwx'
+      notify: Pam_auth_update_pwhistory
+
+    - name: "5.3.2.4 | PATCH | Ensure pam_pwhistory module is enabled | Force pam-auth-update if pam_pwhistory entries are missing"
+      when: discovered_pam_pwhistory_password.stdout | length == 0
+      changed_when: true
+      ansible.builtin.debug:
+        msg: "pam_pwhistory.so is missing from /etc/pam.d/common-password; forcing pam-auth-update."
+      notify: Pam_auth_update_pwhistory

--- a/tasks/section_5/cis_5.3.3.1.x.yml
+++ b/tasks/section_5/cis_5.3.3.1.x.yml
@@ -1,5 +1,25 @@
 ---
 
+- name: "5.3.3.1.1/2/3 | AUDIT | Capture pam configs related files"
+  when:
+    - ubtu24cis_rule_5_3_3_1_1 or
+      ubtu24cis_rule_5_3_3_1_2 or
+      ubtu24cis_rule_5_3_3_1_3
+  tags:
+    - level1-server
+    - level1-workstation
+    - patch
+    - rule_5.3.3.1.1
+    - rule_5.3.3.1.2
+    - rule_5.3.3.1.3
+    - NIST800-53R5_NA
+    - pam
+  ansible.builtin.find:
+    paths:
+      - '/usr/share/pam-configs/'
+      - '/etc/pam.d/'
+  register: discovered_pam_conf_files
+
 - name: "5.3.3.1.1 | PATCH | Ensure password failed attempts lockout is configured"
   when: ubtu24cis_rule_5_3_3_1_1
   tags:
@@ -22,7 +42,11 @@
         mode: 'u-x,go-rwx'
 
     - name: "5.3.3.1.1 | AUDIT | Ensure password failed attempts lockout is configured | discover pam config with deny"
-      ansible.builtin.shell: grep -Pl -- '\bpam_faillock\.so\h+([^#\n\r]+\h+)?deny\b' /usr/share/pam-configs/*
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -Pl -- '\bpam_faillock\.so\h+([^#\n\r]+\h+)?deny\b' /usr/share/pam-configs/*
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
       check_mode: false
       changed_when: false
       failed_when: discovered_faillock_deny_files.rc not in [ 0, 1 ]
@@ -34,7 +58,7 @@
         path: "{{ item.path }}"
         regexp: '(*.pam_faillock.so\s*)deny\s*=\s*\d+\b(.*)'
         replace: \1\2
-      loop: "{{ prelim_pam_conf_files.files }}"
+      loop: "{{ discovered_pam_conf_files.files }}"
       loop_control:
         label: "{{ item }}"
 
@@ -60,7 +84,11 @@
         mode: 'u-x,go-rwx'
 
     - name: "5.3.3.1.2 | AUDIT | Ensure password unlock time is configured | discover pam config with unlock_time"
-      ansible.builtin.shell: grep -Pl -- '\bpam_faillock\.so\h+([^#\n\r]+\h+)?unlock_time\b' /usr/share/pam-configs/*
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -Pl -- '\bpam_faillock\.so\h+([^#\n\r]+\h+)?unlock_time\b' /usr/share/pam-configs/*
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
       check_mode: false
       changed_when: false
       failed_when: discovered_faillock_unlock_files.rc not in [ 0, 1 ]
@@ -72,7 +100,7 @@
         path: "{{ item.path }}"
         regexp: '(*.pam_faillock.so\s*)unlock_time\s*=\s*\b(.*)'
         replace: \1\2
-      loop: "{{ prelim_pam_conf_files.files }}"
+      loop: "{{ discovered_pam_conf_files.files }}"
       loop_control:
         label: "{{ item }}"
 
@@ -102,7 +130,7 @@
         set -o pipefail
         grep -Pl -- '\bpam_faillock\.so\h+([^#\n\r]+\h+)?(even_deny_root|root_unlock_time)' /usr/share/pam-configs/*
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       check_mode: false
       changed_when: false
       failed_when: discovered_faillock_rootlock_files.rc not in [ 0, 1 ]
@@ -114,6 +142,6 @@
         path: "{{ item.path }}"
         regexp: '(*.pam_faillock.so\s*)(even_deny_root\b|root_unlock_time\s*=\s*\d+\b)(.*)'
         replace: \1\3
-      loop: "{{ prelim_pam_conf_files.files }}"
+      loop: "{{ discovered_pam_conf_files.files }}"
       loop_control:
         label: "{{ item }}"

--- a/tasks/section_5/cis_5.3.3.2.x.yml
+++ b/tasks/section_5/cis_5.3.3.2.x.yml
@@ -1,5 +1,39 @@
 ---
 
+- name: "5.3.3.2.1-6 | PATCH | Ensure conf.d directory exists"
+  when:
+    - ubtu24cis_rule_5_3_3_2_1 or
+      ubtu24cis_rule_5_3_3_2_2 or
+      ubtu24cis_rule_5_3_3_2_3 or
+      ubtu24cis_rule_5_3_3_2_4 or
+      ubtu24cis_rule_5_3_3_2_5 or
+      ubtu24cis_rule_5_3_3_2_6
+  tags:
+    - level1-server
+    - level1-workstation
+    - patch
+    - pam
+    - rule_5.3.3.2.1
+    - rule_5.3.3.2.2
+    - rule_5.3.3.2.3
+    - rule_5.3.3.2.4
+    - rule_5.3.3.2.5
+    - rule_5.3.3.2.6
+    - NIST800-53R5_IA-5
+  ansible.builtin.file:
+    path: '/etc/security/pwquality.conf.d'
+    state: directory
+    owner: root
+    group: root
+    mode: 'u+x,g-w,o-rwx'
+
+- name: "5.3.3.2.x | PATCH | Look for existing configs"
+  ansible.builtin.find:
+    paths:
+      - /etc/security/pwquality.conf.d/
+    patterns: '*.conf'
+  register: discovered_pam_pwquality_confs
+
 - name: "5.3.3.2.1 | PATCH | Ensure password number of changed characters is configured"
   when: ubtu24cis_rule_5_3_3_2_1
   tags:
@@ -17,7 +51,7 @@
         regexp: 'difok\s*=\s*\d+\b'
         replace: ''
       with_items:
-        - "{{ prelim_pam_pwquality_confs.files }}"
+        - "{{ discovered_pam_pwquality_confs.files }}"
         - { path: '/etc/security/pwquality.conf'}
         - { path: '/etc/pam.d/common-password' }
       loop_control:
@@ -48,7 +82,7 @@
         regexp: 'minlen\s*=\s*\d+\b'
         replace: ''
       with_items:
-        - "{{ prelim_pam_pwquality_confs.files }}"
+        - "{{ discovered_pam_pwquality_confs.files }}"
         - { path: '/etc/security/pwquality.conf'}
         - { path: '/etc/pam.d/common-password' }
       loop_control:
@@ -79,7 +113,7 @@
         regexp: '(minclass|[dulo]credit)\s*=\s*(-\d|\d+)\b'
         replace: ''
       with_items:
-        - "{{ prelim_pam_pwquality_confs.files }}"
+        - "{{ discovered_pam_pwquality_confs.files }}"
         - { path: '/etc/security/pwquality.conf'}
         - { path: '/etc/pam.d/common-password' }
       loop_control:
@@ -110,7 +144,7 @@
         regexp: 'maxrepeat\s*=\s*\d+\b'
         replace: ''
       with_items:
-        - "{{ prelim_pam_pwquality_confs.files }}"
+        - "{{ discovered_pam_pwquality_confs.files }}"
         - { path: '/etc/security/pwquality.conf'}
         - { path: '/etc/pam.d/common-password' }
       loop_control:
@@ -141,7 +175,7 @@
         regexp: 'maxsequence\s*=\s*\d+\b'
         replace: ''
       with_items:
-        - "{{ prelim_pam_pwquality_confs.files }}"
+        - "{{ discovered_pam_pwquality_confs.files }}"
         - { path: '/etc/security/pwquality.conf'}
         - { path: '/etc/pam.d/common-password' }
       loop_control:
@@ -172,7 +206,7 @@
         regexp: 'dictcheck\s*=\s*\d+\b'
         replace: ''
       with_items:
-        - "{{ prelim_pam_pwquality_confs.files }}"
+        - "{{ discovered_pam_pwquality_confs.files }}"
         - { path: '/etc/security/pwquality.conf'}
         - { path: '/etc/pam.d/common-password' }
       loop_control:
@@ -203,7 +237,7 @@
         regexp: 'enforcing\s*=\s*\d+\b'
         replace: ''
       with_items:
-        - "{{ prelim_pam_pwquality_confs.files }}"
+        - "{{ discovered_pam_pwquality_confs.files }}"
         - { path: '/etc/security/pwquality.conf'}
         - { path: '/etc/pam.d/common-password' }
       loop_control:

--- a/tasks/section_5/cis_5.3.3.3.x.yml
+++ b/tasks/section_5/cis_5.3.3.3.x.yml
@@ -13,7 +13,11 @@
     - pam
   block:
     - name: "5.3.3.3.1 | AUDIT | Ensure password history remember is configured | Check existing files"
-      ansible.builtin.shell: grep -Psi -- '^\h*password\h+[^#\n\r]+\h+pam_pwhistory\.so\h+([^#\n\r]+\h+)?remember=\d+\b' /etc/pam.d/common-password
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -Psi -- '^\h*password\h+[^#\n\r]+\h+pam_pwhistory\.so\h+([^#\n\r]+\h+)?remember=\d+\b' /etc/pam.d/common-password
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
       check_mode: false
       changed_when: false
       failed_when: discovered_pwhistory_remember.rc not in [0, 1]
@@ -41,7 +45,11 @@
     - pam
   block:
     - name: "5.3.3.3.2 | AUDIT | Ensure password history is enforced for the root user | Check existing files"
-      ansible.builtin.shell: grep -Psi -- '^\h*password\h+[^#\n\r]+\h+pam_pwhistory\.so\h+([^#\n\r]+\h+)?enforce_for_root\b' /etc/pam.d/common-password
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -Psi -- '^\h*password\h+[^#\n\r]+\h+pam_pwhistory\.so\h+([^#\n\r]+\h+)?enforce_for_root\b' /etc/pam.d/common-password
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
       check_mode: false
       changed_when: false
       failed_when: discovered_pwhistory_enforce_for_root.rc not in [0, 1]
@@ -69,7 +77,11 @@
     - pam
   block:
     - name: "5.3.3.3.3 | AUDIT | Ensure pam_pwhistory includes use_authtok | Check existing files"
-      ansible.builtin.shell: grep -Psi -- '^\h*password\h+[^#\n\r]+\h+pam_pwhistory\.so\h+([^#\n\r]+\h+)?use_authtok\b' /etc/pam.d/common-password
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -Psi -- '^\h*password\h+[^#\n\r]+\h+pam_pwhistory\.so\h+([^#\n\r]+\h+)?use_authtok\b' /etc/pam.d/common-password
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
       check_mode: false
       changed_when: false
       failed_when: discovered_pwhistory_use_authtok.rc not in [0, 1]

--- a/tasks/section_5/cis_5.3.3.4.x.yml
+++ b/tasks/section_5/cis_5.3.3.4.x.yml
@@ -15,9 +15,9 @@
     - name: "5.3.3.4.1 | PATCH | Ensure pam_unix does not include nullok | capture state"
       ansible.builtin.shell: |
         set -o pipefail
-        grep -E "pam_unix.so.*nullok" /etc/pam.d/common-* /usr/share/pam-configs/* | cut -d ':' -f1 | uniq
+        grep -E "pam_unix.so.*nullok" /etc/pam.d/common-{password,auth,account,session,session-noninteractive} /usr/share/pam-configs/* | cut -d ':' -f1 | uniq
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_pam_nullok.rc not in [ 0, 1 ]
       check_mode: false
@@ -47,9 +47,9 @@
     - name: "5.3.3.4.2 | AUDIT | Ensure pam_unix does not include remember | capture state"
       ansible.builtin.shell: |
         set -o pipefail
-        grep -PH -- '^\h*^\h*[^#\n\r]+\h+pam_unix\.so\b' /etc/pam.d/common-* | grep -P -- "remember=\d+" | cut -d':' -f1
+        grep -PH -- '^\h*^\h*[^#\n\r]+\h+pam_unix\.so\b' /etc/pam.d/common-{password,auth,account,session,session-noninteractive} | grep -P -- "remember=\d+" | cut -d':' -f1
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_pam_remember.rc not in [ 0, 1 ]
       check_mode: false
@@ -77,7 +77,11 @@
     - NIST800-53R5_IA-5
   block:
     - name: "5.3.3.4.3 | AUDIT | Ensure pam_unix includes a strong password hashing algorithm | capture state"
-      ansible.builtin.shell: grep -PH -- '^\h*password\h+([^#\n\r]+)\h+pam_unix\.so\h+([^#\n\r]+\h+)?!("{{ ubtu24cis_passwd_hash_algo }}")\b' /etc/pam.d/common-password
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -PH -- '^\h*password\h+([^#\n\r]+)\h+pam_unix\.so\h+([^#\n\r]+\h+)?!("{{ ubtu24cis_passwd_hash_algo }}")\b' /etc/pam.d/common-password
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_pam_pwhash.rc not in [ 0, 1 ]
       check_mode: false
@@ -102,7 +106,11 @@
     - NIST800-53R5_IA-5
   block:
     - name: "5.3.3.4.4 | PATCH | Ensure pam_unix includes use_authtok | capture state"
-      ansible.builtin.shell: grep -PH -- '^\h*password\h+([^#\n\r]+)\h+pam_unix\.so\h+([^#\n\r]+\h+)?use_authtok\b' /etc/pam.d/common-password
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -PH -- '^\h*password\h+([^#\n\r]+)\h+pam_unix\.so\h+([^#\n\r]+\h+)?use_authtok\b' /etc/pam.d/common-password
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_pam_authtok.rc not in [ 0, 1 ]
       check_mode: false

--- a/tasks/section_5/cis_5.4.1.x.yml
+++ b/tasks/section_5/cis_5.4.1.x.yml
@@ -30,7 +30,7 @@
         set -o pipefail
         awk -F: '(/^[^:]+:[^!*]/ && ($5>{{ ubtu24cis_pass_max_days }} || $5<{{ ubtu24cis_pass_min_days }} || $5 == -1)){print $1}' /etc/shadow
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_passwd_max_days.rc not in [0, 1]
       check_mode: false
@@ -39,21 +39,21 @@
     - name: "5.4.1.1 | AUDIT | Ensure password expiration is configured | Add warning if ansible user found as break connection"
       when:
         - ubtu24cis_disruption_high
-        - (ansible_user | default(ansible_env.USER)) in discovered_passwd_max_days.stdout
+        - (ansible_user | default(ansible_env['USER'])) in discovered_passwd_max_days.stdout
       ansible.builtin.debug:
         msg: "Warning!! Your ansible user found to be not compliant with maxdays - Manual intervention required"
 
     - name: 5.4.1.1 | AUDIT | Ensure password expiration is configured | Warn count"
       when:
         - ubtu24cis_disruption_high
-        - (ansible_user | default(ansible_env.USER)) in discovered_passwd_max_days.stdout
+        - (ansible_user | default(ansible_env['USER'])) in discovered_passwd_max_days.stdout
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 
     - name: "5.4.1.1 | PATCH | Ensure password expiration is configured | Set existing users PASS_MAX_DAYS"
       when:
         - ubtu24cis_disruption_high
-        - item != (ansible_user | default(ansible_env.USER))
+        - item != (ansible_user | default(ansible_env['USER']))
       ansible.builtin.command: "chage --maxdays {{ ubtu24cis_pass_max_days }} {{ item }}"
       failed_when: false
       changed_when: discovered_passwd_max_days.stdout | length > 0
@@ -66,7 +66,7 @@
   tags:
     - level2-server
     - level2-workstation
-    - patch
+    - audit
     - rule_5.4.1.2
     - NIST800-53R5_NA
     - user
@@ -91,21 +91,21 @@
     - name: "5.4.1.2 | AUDIT | Ensure minimum password days is configured | Add warning if ansible user found as break connection"
       when:
         - ubtu24cis_disruption_high
-        - (ansible_user | default(ansible_env.USER)) in discovered_passwd_min_days.stdout
+        - (ansible_user | default(ansible_env['USER'])) in discovered_passwd_min_days.stdout
       ansible.builtin.debug:
         msg: "Warning!! Your ansible user found to be not compliant with mindays - Manual intervention required"
 
     - name: "5.4.1.2 | AUDIT | Ensure minimum password days is configured | Warn count"
       when:
         - ubtu24cis_disruption_high
-        - (ansible_user | default(ansible_env.USER)) in discovered_passwd_min_days.stdout
+        - (ansible_user | default(ansible_env['USER'])) in discovered_passwd_min_days.stdout
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 
     - name: "5.4.1.2 | PATCH | Ensure minimum password days is configured | Set existing users PASS_MIN_DAYS"
       when:
         - ubtu24cis_disruption_high
-        - item != (ansible_user | default(ansible_env.USER))
+        - item != (ansible_user | default(ansible_env['USER']))
       ansible.builtin.command: chage --mindays {{ ubtu24cis_pass_min_days }} {{ item }}
       failed_when: false
       changed_when: discovered_passwd_min_days.stdout | length > 0
@@ -141,7 +141,7 @@
     - name: "5.4.1.3 | PATCH | Ensure password expiration warning days is configured | Set existing users PASS_WARN_AGE"
       when:
         - ubtu24cis_disruption_high
-        - item != (ansible_user | default(ansible_env.USER))
+        - item != (ansible_user | default(ansible_env['USER']))
       ansible.builtin.command: chage --warndays {{ ubtu24cis_pass_warn_age }} {{ item }}
       failed_when: false
       changed_when: discovered_passwd_warn_days.stdout | length > 0
@@ -180,7 +180,7 @@
         set -o pipefail
         useradd -D | grep INACTIVE | cut -d= -f2
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_passwd_inactive_setting.rc not in [0, 1]
       check_mode: false
@@ -227,7 +227,7 @@
     warn_control_id: '5.4.1.6'
   block:
     - name: "5.4.1.6 | AUDIT | Ensure all users last password change date is in the past | Get current date in Unix Time"
-      ansible.builtin.shell: echo $(($(date --utc --date "$1" +%s)/86400))
+      ansible.builtin.command: echo $(($(date --utc --date "$1" +%s)/86400))
       changed_when: false
       failed_when: discovered_current_time.rc not in [0, 1]
       check_mode: false
@@ -238,7 +238,7 @@
         set -o pipefail
         cat /etc/shadow | awk -F: '{if($3>{{ discovered_current_time.stdout }})print$1}'
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_passwd_future_user_list.rc not in [0, 1]
       check_mode: false

--- a/tasks/section_5/cis_5.4.2.x.yml
+++ b/tasks/section_5/cis_5.4.2.x.yml
@@ -1,9 +1,32 @@
 ---
 
+- name: "5.4.2.7/8 | AUDIT | Interactive Users"
+  when:
+    - ubtu24cis_rule_5_4_2_7 or
+      ubtu24cis_rule_5_4_2_8
+  tags:
+    - level1-server
+    - level1-workstation
+    - patch
+    - shadow_suite
+    - rule_5.4.2.7
+    - rule_5.4.2.8
+    - NIST800-53R5_AC-2
+    - NIST800-53R5_AC-3
+    - NIST800-53R5_AC-11
+    - NIST800-53R5_MP-2
+  ansible.builtin.shell: |
+    set -o pipefail
+    grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '(!index($7, "sbin/nologin") && $7 != "/bin/nologin" && $7 != "/bin/false" && $7 != "/dev/null") { print $1 }'
+  args:
+    executable: "{{ ubtu24cis_shell_executable }}"
+  changed_when: false
+  check_mode: false
+  register: discovered_interactive_usernames
+
 - name: "5.4.2.1 | PATCH | Ensure root is the only UID 0 account"
   when:
     - ubtu24cis_rule_5_4_2_1
-    - prelim_uid_zero_accounts_except_root.rc
     - ubtu24cis_disruption_high
   tags:
     - level1-server
@@ -17,12 +40,25 @@
     - NIST800-53R5_CM-6
     - NIST800-53R5_CM-7
     - NIST800-53R5_IA-5
-  ansible.builtin.command: passwd -l {{ item }}
-  changed_when: false
-  failed_when: false
-  loop: "{{ prelim_uid_zero_accounts_except_root.stdout_lines }}"
-  loop_control:
-    label: "{{ item }}"
+  block:
+    - name: "5.4.2.1 | AUDIT | Ensure root is the only UID 0 account | discover"
+      ansible.builtin.shell: |
+        set -o pipefail
+        cat /etc/passwd | awk -F: '($3 == 0 && $1 != "root") {i++;print $1 } END {exit i}'
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
+      changed_when: false
+      check_mode: false
+      register: discovered_uid_zero_accounts_except_root
+
+    - name: "5.4.2.1 | PATCH | Ensure root is the only UID 0 account | lock non root"
+      when: discovered_uid_zero_accounts_except_root.rc
+      ansible.builtin.command: passwd -l {{ item }}
+      changed_when: false
+      failed_when: false
+      loop: "{{ discovered_uid_zero_accounts_except_root.stdout_lines }}"
+      loop_control:
+        label: "{{ item }}"
 
 - name: "5.4.2.2 | PATCH | Ensure root is the only GID 0 account"
   when:
@@ -46,7 +82,7 @@
         set -o pipefail
         awk -F: '($1 !~ /^(sync|shutdown|halt|operator)/ && $4=="0") {print $1}' /etc/passwd | grep -wv 'root'
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_gid0_members.rc not in [ 0, 1 ]
       check_mode: false
@@ -85,7 +121,7 @@
         set -o pipefail
         awk -F: '$3=="0"{print $1}' /etc/group | grep -vw 'root'
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       check_mode: false
       changed_when: false
       failed_when: discovered_gid0_groups.rc not in [ 0, 1 ]
@@ -140,7 +176,7 @@
         set -o pipefail
         sudo -Hiu root env | grep '^PATH' | cut -d= -f2
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       check_mode: false
       register: discovered_root_paths
@@ -151,7 +187,7 @@
         set -o pipefail
         sudo -Hiu root env | grep '^PATH' | cut -d= -f2 | tr ":" "\n"
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       check_mode: false
       register: discovered_root_paths_split
@@ -167,7 +203,7 @@
         set -o pipefail
         echo {{ root_paths }} | grep -q "::" && echo "roots path contains a empty directory (::)"
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_root_path_empty_dir.rc not in [ 0, 1 ]
       check_mode: false
@@ -179,7 +215,7 @@
         set -o pipefail
         echo {{ root_paths }} | cut -d= -f2 | grep -q ":$" && echo "roots path contains a trailing (:)"
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_root_path_trailing_colon.rc not in [ 0, 1 ]
       check_mode: false
@@ -232,7 +268,7 @@
 - name: "5.4.2.7 | PATCH | Ensure system accounts do not have a valid login shell"
   when:
     - ubtu24cis_rule_5_4_2_7
-    - "item.id not in prelim_interactive_usernames.stdout"
+    - "item.id not in discovered_interactive_usernames.stdout"
     - "'root' not in item.id"
     - ubtu24cis_disruption_high
   tags:
@@ -257,7 +293,7 @@
   when:
     - ubtu24cis_rule_5_4_2_8
     - ubtu24cis_disruption_high
-    - "item.id not in prelim_interactive_usernames.stdout"
+    - "item.id not in discovered_interactive_usernames.stdout"
     - "'root' not in item.id"
   tags:
     - level1-server

--- a/tasks/section_6/cis_6.1.1.x.yml
+++ b/tasks/section_6/cis_6.1.1.x.yml
@@ -1,5 +1,30 @@
 ---
 
+- name: "6.1.1.3 6.1.2.2/3/4 | PATCH | Create journald conf.d directory"
+  when:
+    - ubtu24cis_rule_6_1_1_3 or
+      ubtu24cis_rule_6_1_2_2 or
+      ubtu24cis_rule_6_1_2_3 or
+      ubtu24cis_rule_6_1_2_4
+  tags:
+    - level1-server
+    - level1-workstation
+    - audit
+    - journald
+    - rule_6.1.1.3
+    - rule_6.1.2.2
+    - rule_6.1.2.3
+    - rule_6.1.2.4
+    - NIST800-53R5_AU-2
+    - NIST800-53R5_AU-7
+    - NIST800-53R5_AU-12
+  ansible.builtin.file:
+    path: /etc/systemd/journald.conf.d
+    state: directory
+    owner: root
+    group: root
+    mode: 'u+x,go-w'
+
 - name: "6.1.1.1 | PATCH | Ensure journald service is enabled and active"
   when: ubtu24cis_rule_6_1_1_1
   tags:
@@ -43,7 +68,11 @@
 
     - name: "6.1.1.2 | AUDIT | Ensure journald log file access is configured | If override file check for journal"
       when: discovered_journald_tmpfile_override.stat.exists
-      ansible.builtin.shell: grep -E 'z /var/log/journal/%m/system.journal \d*' /usr/lib/tmpfiles.d/systemd.conf
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -E 'z /var/log/journal/%m/system.journal \d*' /usr/lib/tmpfiles.d/systemd.conf
+      args:
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_journald_fileperms_override.rc not in [ 0, 1 ]
       check_mode: false
@@ -70,7 +99,7 @@
   tags:
     - level1-server
     - level1-workstation
-    - patch
+    - audit
     - journald
     - rule_6.1.1.3
     - NIST800-53R5_AU-2
@@ -122,7 +151,7 @@
             enabled: true
 
         - name: "6.1.1.4 | PATCH | Ensure only one logging system is in use | If journald"
-          when: "'rsyslog' in ansible_facts.packages"
+          when: "'rsyslog' in ansible_facts['packages']"
           ansible.builtin.systemd:
             name: rsyslog.service
             state: stopped
@@ -138,7 +167,7 @@
             enabled: true
 
         - name: "6.1.1.4 | PATCH | Ensure only one logging system is in use | If rsyslog"
-          when: "'systemd-journal' in ansible_facts.packages"
+          when: "'systemd-journal' in ansible_facts['packages']"
           ansible.builtin.systemd:
             name: systemd-journald.service
             state: stopped

--- a/tasks/section_6/cis_6.1.2.x.yml
+++ b/tasks/section_6/cis_6.1.2.x.yml
@@ -25,7 +25,7 @@
   tags:
     - level1-server
     - level1-workstation
-    - patch
+    - audit
     - journald
     - rule_6.1.2.1.2
     - NIST800-53R5_AU-2

--- a/tasks/section_6/cis_6.1.3.8.yml
+++ b/tasks/section_6/cis_6.1.3.8.yml
@@ -3,12 +3,12 @@
 - name: "6.1.3.8 | PATCH | Ensure logrotate is configured"
   when:
     - ubtu24cis_rule_6_1_3_8
-    - "'logrotate' in ansible_facts.packages"
+    - "'logrotate' in ansible_facts['packages']"
   tags:
     - level1-server
     - level1-workstation
     - manual
-    - patch
+    - audit
     - logrotate
     - rule_6.1.3.8
     - NIST800-53R5_AU-8

--- a/tasks/section_6/cis_6.1.3.x.yml
+++ b/tasks/section_6/cis_6.1.3.x.yml
@@ -3,7 +3,7 @@
 - name: "6.1.3.1 | PATCH | Ensure rsyslog is installed"
   when:
     - ubtu24cis_rule_6_1_3_1
-    - "'rsyslog' not in ansible_facts.packages"
+    - "'rsyslog' not in ansible_facts['packages']"
   tags:
     - level1-server
     - level1-workstation
@@ -80,7 +80,7 @@
     - level1-server
     - level1-workstation
     - manual
-    - patch
+    - audit
     - rule_6.1.3.5
     - NIST800-53R5_AU-2
     - NIST800-53R5_AU-7
@@ -94,7 +94,7 @@
         set -o pipefail
         grep -r "*.emerg" /etc/* | cut -f1 -d":"
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_rsyslog_config_path.rc not in [0, 1]
       check_mode: false
@@ -153,7 +153,7 @@
     - level1-server
     - level1-workstation
     - automated
-    - patch
+    - audit
     - rule_6.1.3.6
     - NIST800-53R5_AU-6
     - rsyslog

--- a/tasks/section_6/cis_6.1.4.1.yml
+++ b/tasks/section_6/cis_6.1.4.1.yml
@@ -12,7 +12,7 @@
     - NIST800-53R5_MP-2
   block:
     - name: "6.1.4.1 | AUDIT | Ensure access to all logfiles has been configured | find files"
-      ansible.builtin.shell: find /var/log/ -type f -exec ls {} \;
+      ansible.builtin.command: find /var/log/ -type f -exec ls {} \;
       changed_when: false
       failed_when: discovered_logfiles.rc not in [0, 1]
       check_mode: false

--- a/tasks/section_6/cis_6.2.1.x.yml
+++ b/tasks/section_6/cis_6.2.1.x.yml
@@ -1,9 +1,7 @@
 ---
 
 - name: "6.2.1.1 | PATCH | Ensure auditd packages are installed"
-  when:
-    - ubtu24cis_rule_6_2_1_1
-    - "'auditd' not in ansible_facts.packages or 'audispd-plugins' not in ansible_facts.packages"
+  when: ubtu24cis_rule_6_2_1_1
   tags:
     - level2-server
     - level2-workstation
@@ -53,7 +51,7 @@
         set -o pipefail
         grep "GRUB_CMDLINE_LINUX=" /etc/default/grub | cut -f2 -d'"'
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_grub_cmdline_settings_auditd.rc not in [0, 1]
       check_mode: false
@@ -94,7 +92,7 @@
         set -o pipefail
         grep "GRUB_CMDLINE_LINUX=" /etc/default/grub | cut -f2 -d'"'
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_audit_backlog_grub_cmdline_settings.rc not in [0, 1]
       check_mode: false
@@ -105,14 +103,14 @@
       ansible.builtin.lineinfile:
         path: /etc/default/grub
         regexp: '^GRUB_CMDLINE_LINUX='
-        line: 'GRUB_CMDLINE_LINUX="{{ discovered_audit_backlog_grub_cmdline_settings.stdout }} audit_backlog_limit={{ ubtu24cis_audit_back_log_limit }}"'
+        line: 'GRUB_CMDLINE_LINUX="{{ discovered_audit_backlog_grub_cmdline_settings.stdout }} audit_backlog_limit={{ ubtu24cis_auditd_back_log_limit }}"'
       notify: Grub update
 
     - name: "6.2.1.4 | PATCH | Ensure audit_backlog_limit is sufficient | Update setting if exists"
       ansible.builtin.replace:
         dest: /etc/default/grub
         regexp: 'audit_backlog_limit=([0-9]+)'
-        replace: 'audit_backlog_limit={{ ubtu24cis_audit_back_log_limit }}'
+        replace: 'audit_backlog_limit={{ ubtu24cis_auditd_back_log_limit }}'
         after: '^GRUB_CMDLINE_LINUX="'
         before: '"'
       notify: Grub update

--- a/tasks/section_6/cis_6.2.2.x.yml
+++ b/tasks/section_6/cis_6.2.2.x.yml
@@ -14,7 +14,7 @@
     regexp: "^max_log_file( |=)"
     line: "max_log_file = {{ ubtu24cis_max_log_file_size }}"
     state: present
-  notify: Restart auditd
+  notify: Update auditd
 
 - name: "6.2.2.2 | PATCH | Ensure audit logs are not automatically deleted"
   when: ubtu24cis_rule_6_2_2_2
@@ -29,7 +29,7 @@
     path: /etc/audit/auditd.conf
     regexp: '^max_log_file_action'
     line: "max_log_file_action = {{ ubtu24cis_auditd_max_log_file_action }}"
-  notify: Restart auditd
+  notify: Update auditd
 
 - name: "6.2.2.3 | PATCH | Ensure system is disabled when audit logs are full"
   when: ubtu24cis_rule_6_2_2_3
@@ -49,7 +49,7 @@
     - { regexp: '^disk_error_action', line: "disk_error_action = {{ ubtu24cis_auditd_disk_error_action }}" }
   loop_control:
     label: "{{ item }}"
-  notify: Restart auditd
+  notify: Update auditd
 
 - name: "6.2.2.4 | PATCH | Ensure system warns when audit logs are low on space"
   when: ubtu24cis_rule_6_2_2_4
@@ -72,4 +72,4 @@
     - { regexp: '^space_left_action', line: 'space_left_action = {{ ubtu24cis_auditd_space_left_action }}' }
   loop_control:
     label: "{{ item }}"
-  notify: Restart auditd
+  notify: Update auditd

--- a/tasks/section_6/cis_6.2.3.x.yml
+++ b/tasks/section_6/cis_6.2.3.x.yml
@@ -263,7 +263,7 @@
     - level2-server
     - level2-workstation
     - scored
-    - patch
+    - audit
     - rule_6.2.3.21
     - NIST800-53R5_AU-3
     - auditd

--- a/tasks/section_6/cis_6.2.4.x.yml
+++ b/tasks/section_6/cis_6.2.4.x.yml
@@ -1,5 +1,43 @@
 ---
 
+- name: "6.2.4.1/2/3/4| AUDIT | Capture logfile location"
+  when:
+    - ubtu24cis_rule_6_2_4_1 or
+      ubtu24cis_rule_6_2_4_2 or
+      ubtu24cis_rule_6_2_4_3 or
+      ubtu24cis_rule_6_2_4_4
+  tags:
+    - level1-server
+    - level1-workstation
+    - patch
+    - auditd
+    - rule_6.2.4.1
+    - rule_6.2.4.2
+    - rule_6.2.4.3
+    - rule_6.2.4.4
+    - NIST800-53R5_AU-3
+  ansible.builtin.shell: |
+    set -o pipefail
+    grep ^log_file /etc/audit/auditd.conf | awk '{ print $NF }'
+  args:
+    executable: "{{ ubtu24cis_shell_executable }}"
+  changed_when: false
+  check_mode: false
+  failed_when: discovered_auditd_logfile.rc not in [ 0, 1 ]
+  register: discovered_auditd_logfile
+
+- name: "6.2.4.5/6/7 | AUDIT | Audit conf and rules files | list files"
+  when:
+    - ubtu24cis_rule_6_2_4_5 or
+      ubtu24cis_rule_6_2_4_6 or
+      ubtu24cis_rule_6_2_4_7
+  ansible.builtin.find:
+    path: /etc/audit/
+    file_type: file
+    recurse: true
+    patterns: '*.conf,*.rules'
+  register: discovered_auditd_conf_file
+
 - name: "6.2.4.1 | PATCH | Ensure audit log files mode is configured"
   when: ubtu24cis_rule_6_2_4_1
   tags:
@@ -10,7 +48,7 @@
     - rule_6.2.4.1
     - NIST800-53R5_AU-3
   ansible.builtin.file:
-    path: "{{ prelim_auditd_logfile.stdout | dirname }}"
+    path: "{{ discovered_auditd_logfile.stdout | dirname }}"
     recurse: true
     mode: 'u-x,g-wx,o-rwx'
 
@@ -24,7 +62,7 @@
     - rule_6.2.4.2
     - NIST800-53R5_AU-3
   ansible.builtin.file:
-    path: "{{ prelim_auditd_logfile.stdout | dirname }}"
+    path: "{{ discovered_auditd_logfile.stdout | dirname }}"
     recurse: true
     owner: root
 
@@ -40,7 +78,7 @@
   block:
     - name: "6.2.4.3 | AUDIT | Ensure audit log files group owner is configured | stat logfile"
       ansible.builtin.find:
-        path: "{{ prelim_auditd_logfile.stdout | dirname }}"
+        path: "{{ discovered_auditd_logfile.stdout | dirname }}"
         file_type: file
       register: discovered_auditd_logs
 
@@ -65,7 +103,7 @@
   block:
     - name: "6.2.4.4 | AUDIT | Ensure the audit log file directory mode is configured | get current permissions"
       ansible.builtin.stat:
-        path: "{{ prelim_auditd_logfile.stdout | dirname }}"
+        path: "{{ discovered_auditd_logfile.stdout | dirname }}"
       register: discovered_auditlog_dir
 
     - name: "6.2.4.4 | PATCH | Ensure the audit log file directory mode is configured | set permissions"
@@ -86,7 +124,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     mode: 'u-x,g-wx,o-rwx'
-  loop: "{{ prelim_auditd_conf_files.files }}"
+  loop: "{{ discovered_auditd_conf_file.files }}"
   loop_control:
     label: "{{ item.path }}"
 
@@ -102,7 +140,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     owner: root
-  loop: "{{ prelim_auditd_conf_files.files }}"
+  loop: "{{ discovered_auditd_conf_file.files }}"
   loop_control:
     label: "{{ item.path }}"
 
@@ -118,7 +156,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     group: root
-  loop: "{{ prelim_auditd_conf_files.files }}"
+  loop: "{{ discovered_auditd_conf_file.files }}"
   loop_control:
     label: "{{ item.path }}"
 

--- a/tasks/section_6/cis_6.3.x.yml
+++ b/tasks/section_6/cis_6.3.x.yml
@@ -12,7 +12,7 @@
     - aide
   block:
     - name: "6.3.1 | PATCH | Ensure AIDE is installed"
-      when: "'aide' not in ansible_facts.packages or 'aide-common' not in ansible_facts.packages"
+      when: "'aide' not in ansible_facts['packages'] or 'aide-common' not in ansible_facts['packages']"
       ansible.builtin.package:
         name: ['aide', 'aide-common']
         state: present

--- a/tasks/section_7/cis_7.1.x.yml
+++ b/tasks/section_7/cis_7.1.x.yml
@@ -192,7 +192,7 @@
         set -o pipefail
         df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f -perm -0002
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       failed_when: discovered_worldwriteable_files.rc not in [0, 1]
       changed_when: false
       check_mode: false
@@ -215,7 +215,7 @@
         set -o pipefail
         df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type d -perm -0002 2>/dev/null | xargs chmod a+t
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: false
 
@@ -239,7 +239,7 @@
       check_mode: false
       register: discovered_unowned_files
       with_items:
-        - "{{ ansible_facts.mounts }}"
+        - "{{ ansible_facts['mounts'] }}"
       loop_control:
         label: "{{ item.mount }}"
 
@@ -300,7 +300,7 @@
       check_mode: false
       register: discovered_suid_sgid_files
       with_items:
-        - "{{ ansible_facts.mounts }}"
+        - "{{ ansible_facts['mounts'] }}"
       loop_control:
         label: "{{ item.mount }}"
 

--- a/tasks/section_7/cis_7.2.x.yml
+++ b/tasks/section_7/cis_7.2.x.yml
@@ -1,5 +1,30 @@
 ---
 
+- name: "7.2.9/10 | AUDIT | Interactive User accounts home directories"
+  when:
+    - ubtu24cis_rule_7_2_9
+    - ubtu24cis_rule_7_2_10
+  tags:
+    - level1-server
+    - level1-workstation
+    - patch
+    - rule_7.2.9
+    - rule_7.2.10
+    - NIST800-53R5_CM-1
+    - NIST800-53R5_CM-2
+    - NIST800-53R5_CM-6
+    - NIST800-53R5_CM-7
+    - NIST800-53R5_IA-5
+    - user
+  ansible.builtin.shell: |
+    set -o pipefail
+    grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '(!index($7, "sbin/nologin") && $7 != "/bin/nologin" && $7 != "/bin/false" && $7 != "/dev/null") { print $6 }'
+  args:
+    executable: "{{ ubtu24cis_shell_executable }}"
+  changed_when: false
+  check_mode: false
+  register: discovered_interactive_users_home
+
 - name: "7.2.1 | AUDIT | Ensure accounts in /etc/passwd use shadowed passwords"
   when: ubtu24cis_rule_7_2_1
   tags:
@@ -13,7 +38,7 @@
     warn_control_id: '7.2.1'
   block:
     - name: "7.2.1 | AUDIT | Ensure accounts in /etc/passwd use shadowed passwords | Get users not using shadowed passwords"
-      ansible.builtin.shell: awk -F':' '($2 != "x" ) { print $1}' /etc/passwd
+      ansible.builtin.command: awk -F':' '($2 != "x" ) { print $1}' /etc/passwd
       changed_when: false
       failed_when: discovered_nonshadowed_users.rc not in [0, 1]
       check_mode: false
@@ -44,7 +69,7 @@
   no_log: true
   block:
     - name: "7.2.2 | AUDIT | Ensure /etc/shadow password fields are not empty | Find users with no password"
-      ansible.builtin.shell: awk -F":" '($2 == "" ) { print $1 }' /etc/shadow
+      ansible.builtin.command: awk -F":" '($2 == "" ) { print $1 }' /etc/shadow
       changed_when: false
       check_mode: false
       register: discovered_empty_password_acct
@@ -80,7 +105,7 @@
         set -o pipefail
         pwck -r | grep 'no group' | awk '{ gsub("[:\47]",""); print $2}'
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: false
       check_mode: false
@@ -115,12 +140,12 @@
         key: shadow
 
     - name: "7.2.4 | AUDIT | Ensure shadow group is empty | check users in group"
-      when: ansible_facts.getent_group.shadow[2] | length > 0
+      when: ansible_facts['getent_group']['shadow'][2] | length > 0
       ansible.builtin.debug:
         msg: "Warning!! - You have users in the shadow group"
 
     - name: "7.2.4 | AUDIT | Ensure shadow group is empty | check users in group"
-      when: ansible_facts.getent_group.shadow[2] | length > 0
+      when: ansible_facts['getent_group']['shadow'][2] | length > 0
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 
@@ -145,7 +170,7 @@
         set -o pipefail
         pwck -r | awk -F: '{if ($3 in uid) print $1 ; else uid[$3]}' /etc/passwd
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: false
       check_mode: false
@@ -182,7 +207,7 @@
         set -o pipefail
         pwck -r | awk -F: '{if ($3 in users) print $1 ; else users[$3]}' /etc/group
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: false
       check_mode: false
@@ -219,7 +244,7 @@
         set -o pipefail
         pwck -r | awk -F: '{if ($1 in users) print $1 ; else users[$1]}' /etc/passwd
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: false
       check_mode: false
@@ -256,7 +281,7 @@
         set -o pipefail
         getent passwd | cut -d: -f1 | sort -n | uniq -d
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: false
       check_mode: false
@@ -302,7 +327,7 @@
         etype: group
         permissions: rx
         state: present
-      loop: "{{ prelim_interactive_users_home.stdout_lines }}"
+      loop: "{{ discovered_interactive_users_home.stdout_lines }}"
 
     - name: "7.2.9 | PATCH | Ensure local interactive user home directories are configured | Set other ACL"
       when: not system_is_container
@@ -312,7 +337,7 @@
         etype: other
         permissions: 0
         state: present
-      loop: "{{ prelim_interactive_users_home.stdout_lines }}"
+      loop: "{{ discovered_interactive_users_home.stdout_lines }}"
 
 - name: "7.2.10 | PATCH | Ensure local interactive user dot files access is configured"
   when:
@@ -335,9 +360,9 @@
     - name: "7.2.10 | AUDIT | Ensure local interactive user dot files access is configured"
       ansible.builtin.shell: |
         set -o pipefail
-        find {{ prelim_interactive_users_home.stdout_lines | list | join(' ') }} -name "\.*" -type f
+        find {{ discovered_interactive_users_home.stdout_lines | list | join(' ') }} -name "\.*" -type f{% for f in ubtu24cis_dotfile_exclusions %} ! -name "{{ f }}"{% endfor %}
       args:
-        executable: /bin/bash
+        executable: "{{ ubtu24cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_homedir_hidden_files.rc not in [ 0, 1 ]
       check_mode: false
@@ -385,8 +410,8 @@
         - name: "7.2.10 | AUDIT | Ensure local interactive user dot files access is configured | Changes files ownerships"
           ansible.builtin.file:
             path: "{{ item }}"
-            owner: "{{ prelim_captured_passwd_data | selectattr('dir', 'in', prelim_interactive_users_home.stdout_lines) | selectattr('dir', 'in', item) | map(attribute='uid') | last }}"
-            group: "{{ prelim_captured_passwd_data | selectattr('dir', 'in', prelim_interactive_users_home.stdout_lines) | selectattr('dir', 'in', item) | map(attribute='gid') | last }}"
+            owner: "{{ prelim_captured_passwd_data | selectattr('dir', 'in', discovered_interactive_users_home.stdout_lines) | selectattr('dir', 'in', item) | map(attribute='uid') | last }}"
+            group: "{{ prelim_captured_passwd_data | selectattr('dir', 'in', discovered_interactive_users_home.stdout_lines) | selectattr('dir', 'in', item) | map(attribute='gid') | last }}"
           failed_when: discovered_dot_bash_history_to_change_ownership.state not in '[ file, absent ]'
           register: discovered_dot_bash_history_to_change_ownership
           loop: "{{ discovered_homedir_hidden_files.stdout_lines }}"
@@ -395,8 +420,8 @@
           ansible.builtin.file:
             path: '{{ item }}'
             mode: 'go-w'
-            owner: "{{ prelim_captured_passwd_data | selectattr('dir', 'in', prelim_interactive_users_home.stdout_lines) | selectattr('dir', 'in', item) | map(attribute='uid') | last }}"
-            group: "{{ prelim_captured_passwd_data | selectattr('dir', 'in', prelim_interactive_users_home.stdout_lines) | selectattr('dir', 'in', item) | map(attribute='gid') | last }}"
+            owner: "{{ prelim_captured_passwd_data | selectattr('dir', 'in', discovered_interactive_users_home.stdout_lines) | selectattr('dir', 'in', item) | map(attribute='uid') | last }}"
+            group: "{{ prelim_captured_passwd_data | selectattr('dir', 'in', discovered_interactive_users_home.stdout_lines) | selectattr('dir', 'in', item) | map(attribute='gid') | last }}"
           with_items: "{{ discovered_homedir_hidden_files.stdout_lines }}"
 
         - name: "7.2.10 | AUDIT | Ensure local interactive user dot files access is configured | rename .forward or .rhosts files"

--- a/templates/etc/rsyslog.d/60-rsyslog.conf.j2
+++ b/templates/etc/rsyslog.d/60-rsyslog.conf.j2
@@ -1,0 +1,8 @@
+{{ file_managed_by_ansible }}
+
+
+*.* action(type="omfwd" target="{{ ubtu24cis_remote_log_server }}"
+port="{{ ubtu24cis_remote_log_port }}" protocol="{{ ubtu24cis_remote_log_protocol }}"
+ action.resumeRetryCount="100"
+
+queue.type="LinkedList" queue.size="1000")

--- a/templates/lockdown_audit.yml.j2
+++ b/templates/lockdown_audit.yml.j2
@@ -469,6 +469,10 @@ ubtu24cis_desktop_required: {{ ubtu24cis_desktop_required }}
 
 ## Section 1
 
+# A location that can be used as a temporary location to execute scripts
+# note the drive with need exec permissions used by 1.1.1.10
+ubtu24cis_temp_exec_location: {{ ubtu24cis_temp_exec_location }}
+
 # If system uses squashfs e.gf. snap package manager set true
 ubtu24cis_squashfs_skip:{% if (prelim_squashfs_builtin.rc | default(1)) == 0  or (prelim_snap_pkg_mgr.rc | default(1)) == 0 %} true{% else %} false{% endif %}
 
@@ -570,7 +574,7 @@ ubtu24cis_xwindow_server: {{ ubtu24cis_xwindow_server }}  # will remove mask not
 ubtu24cis_is_mail_server: {{ ubtu24cis_is_mail_server }}
 
 # Client Services
-ubtu24cis_nis_client_required: {{ ubtu24cis_nis_server }}  # Same package as NIS server
+# ubtu24cis_nis_client_required: {{ ubtu24cis_nis_server }}  # Same package as NIS server
 ubtu24cis_rsh_client: {{ ubtu24cis_rsh_client }}
 ubtu24cis_talk_client: {{ ubtu24cis_talk_client }}
 ubtu24cis_telnet_required: {{ ubtu24cis_telnet_required }}
@@ -579,7 +583,7 @@ ubtu24cis_ftp_client: {{ ubtu24cis_ftp_client }}
 
 ## Control 2.3.1.1
 # This variable choses the tool used for time synchronization
-# The two options are `chrony`and `systemd-timesyncd`.
+# The two options are `chrony` and `systemd-timesyncd`.
 ubtu24cis_time_sync_tool: {{ ubtu24cis_time_sync_tool }}
 
 ## Controls 2.3.x - Configure time pools & servers for chrony and timesyncd
@@ -637,93 +641,36 @@ ubtu24cis_sysctl_network_conf: {{ ubtu24cis_sysctl_network_conf }}
 ubtu24cis_firewall_package: {{ ubtu24cis_firewall_package }}
 
 ## auditd settings
-ubtu24cis_auditd:
-  space_left_action: {{ ubtu24cis_auditd_space_left_action }}
-  admin_space_left_action: {{ ubtu24cis_auditd_admin_space_left_action }}
-  max_log_file_action: {{ ubtu24cis_auditd_max_log_file_action }}
-  auditd_backlog_limit: {{ ubtu24cis_audit_back_log_limit }}
+ubtu24cis_auditd_space_left_action: {{ ubtu24cis_auditd_space_left_action }}
+ubtu24cis_auditd_admin_space_left_action: {{ ubtu24cis_auditd_admin_space_left_action }}
+ubtu24cis_auditd_max_log_file_action: {{ ubtu24cis_auditd_max_log_file_action }}
+ubtu24cis_auditd_back_log_limit: {{ ubtu24cis_auditd_back_log_limit }}
 
 ## syslog
 # Set which syslog service
 # journald or rsyslog
 ubtu24cis_syslog_service: {{ ubtu24cis_syslog_service }}
-ubtu24cis_is_syslog_server: {{ ubtu24cis_system_is_log_server }}
+ubtu24cis_system_is_log_server: {{ ubtu24cis_system_is_log_server }}
 
 ### Section 5
 
 # Note the following to understand precedence and layout
-ubtu24cis_sshd_access:
-  - AllowUser {{ ubtu24cis_sshd_allow_users }}
-  - AllowGroup {{ ubtu24cis_sshd_allow_groups }}
-  - DenyUser {{ ubtu24cis_sshd_deny_users }}
-  - DenyGroup {{ ubtu24cis_sshd_deny_groups }}
 
-ubtu24cis_ssh_strong_ciphers:
-  - aes256-gcm@openssh.com
-  - aes128-gcm@openssh.com
-  - aes256-ctr
-  - aes192-ctr
-  - aes128-ctr
-ubtu24cis_ssh_weak_ciphers:
-  - 3des-cbc
-  - aes128-cbc
-  - aes192-cbc
-  - aes256-cbc
-  - arcfour
-  - chacha20-poly1305@openssh.com
-  - arcfour128
-  - arcfour256
-  - blowfish-cbc
-  - cast128-cbc
-  - rijndael-cbc@lysator.liu.se
+ubtu24cis_sshd_allow_users: AllowUsers {% if ubtu24cis_sshd_allow_users | length > 0 %}{{ ubtu24cis_sshd_allow_users }}{% endif %}
 
-ubtu24cis_ssh_strong_macs:
-  - HMAC-SHA1
-  - hmac-sha2-256
-  - hmac-sha2-512
-ubtu24cis_ssh_weak_macs:
-  - hmac-md5
-  - hmac-md5-96
-  - hmac-ripemd160
-  - hmac-sha1-96
-  - umac-64@openssh.com
-  - umac-128@openssh.com
-  - hmac-md5-etm@openssh.com
-  - hmac-md5-96-etm@openssh.com
-  - hmac-ripemd160-etm@openssh.com
-  - hmac-sha1-etm@openssh.com
-  - hmac-sha1-96-etm@openssh.com
-  - umac-64-etm@openssh.com
-  - umac-128-etm@openssh.com
-  - hmac-sha2-512-etm@openssh.com
-  - hmac-sha2-256-etm@openssh.com
+ubtu24cis_sshd_allow_groups: AllowGroups {% if ubtu24cis_sshd_allow_groups | length > 0 %}{{ ubtu24cis_sshd_allow_groups }}{% endif %}
 
-ubtu24cis_ssh_strong_kex:
-  - ecdh-sha2-nistp256
-  - ecdh-sha2-nistp521
-  - diffie-hellman-group-exchange-sha256
-  - diffie-hellman-group14-sha256
-  - diffie-hellman-group16-sha512
-  - diffie-hellman-group18-sha512
-ubtu24cis_ssh_weak_kex:
-  - diffie-hellman-group1-sha1
-  - diffie-hellman-group14-sha1
-  - diffie-hellman-group-exchange-sha1
+ubtu24cis_sshd_deny_users:  DenyUsers {% if ubtu24cis_sshd_deny_users | length > 0 %}{{ ubtu24cis_sshd_deny_users }}{% endif %}
 
-ubtu24cis_ssh_aliveinterval: 300
-ubtu24cis_ssh_countmax: 3
-## PAM
-ubtu24cis_pam_password:
-  minlen: "14"
-  minclass: "4"
+ubtu24cis_sshd_deny_groups: DenyGroups {% if ubtu24cis_sshd_deny_groups | length > 0 %}{{ ubtu24cis_sshd_deny_groups }}{% endif %}
 
-ubtu24cis_pam_passwd_retry: "3"
+ubtu24cis_sshd_client_alive_interval: {{ ubtu24cis_sshd_client_alive_interval }}
+ubtu24cis_sshd_client_alive_count_max: {{ ubtu24cis_sshd_client_alive_count_max }}
 
 # logins.def password settings
-ubtu24cis_pass:
-  max_days: {{ ubtu24cis_pass_max_days }}
-  min_days: {{ ubtu24cis_pass_min_days }}
-  warn_age: {{ ubtu24cis_pass_warn_age }}
+ubtu24cis_pass_max_days: {{ ubtu24cis_pass_max_days }}
+ubtu24cis_pass_min_days: {{ ubtu24cis_pass_min_days }}
+ubtu24cis_pass_warn_age: {{ ubtu24cis_pass_warn_age }}
 
 # set sugroup if differs from wheel
 ubtu24cis_sugroup: nosugroup
@@ -743,3 +690,8 @@ ubtu24cis_config_aide: {{ ubtu24cis_config_aide }}
 
 # aide setup via - cron, timer
 ubtu24cis_aide_scan: {{ ubtu24cis_aide_scan }}
+
+# 6.1.3.6 rsyslog remote offload server
+# ubtu24cis_remote_log_server: taken from above
+ubtu24cis_remote_log_port: {{ ubtu24cis_remote_log_port }}
+ubtu24cis_remote_log_protocol: {{ ubtu24cis_remote_log_protocol }}

--- a/vars/audit.yml
+++ b/vars/audit.yml
@@ -5,8 +5,45 @@
 # Timeout for those cmds that take longer to run where timeout set
 audit_cmd_timeout: 120000
 
+# How to retrieve audit binary
+# Options are copy or download - detailed settings at the bottom of this file
+# you will need to access to either github or the file already downloaded
+get_audit_binary_method: download
+
+## if get_audit_binary_method - copy the following needs to be updated for your environment
+## it is expected that it will be copied from somewhere accessible to the control node
+## e.g copy from ansible control node to remote host
+audit_bin_copy_location: /some/accessible/path
+
+# Ability to limit the number of concurrent processes used by goss (default 50)
+audit_max_concurrent: 50
+
+# how to get audit files onto host options
+# options are git/copy/archive/get_url other e.g. if you wish to run from already downloaded conf
+audit_content: git
+
+# Depending on the method of getting the audit content you may need to validate certs if using git or get_url
+# note is self hosted you may not have the cert chain installed so may need to set to false - this is not recommended but may be required in some environments
+audit_bin_validate_certs: true
+
+# If using either archive, copy, get_url:
+## Note will work with .tar files - zip will require extra configuration
+### If using get_url this is expecting github url in tar.gz format e.g.
+### https://github.com/ansible-lockdown/SUSE16-CIS-Audit/archive/refs/heads/benchmark-v1.0.0.tar.gz
+audit_conf_source: "some path or url to copy from"
+
+# Destination for the audit content to be placed on managed node
+# note may not need full path e.g. /opt with the directory being the {{ benchmark }}-Audit directory
+audit_conf_dest: "/opt"
+
+# Where the audit logs are stored
+audit_log_dir: '/opt'
+
+### options below this line don't often need changing but can be if your environment requires it
+# - e.g. timeout for long running cmds, location of goss binary if using copy method, url for goss binary if using download method etc. ###
+
 # if get_audit_binary_method == download change accordingly
-audit_bin_url: "https://github.com/goss-org/goss/releases/download/{{ audit_bin_version.release }}/goss-linux-"
+audit_bin_url: "https://github.com/krameff/goss/releases/download/{{ audit_bin_version.release }}/goss-linux-"
 
 ### Goss Audit Benchmark file ###
 ## managed by the control audit_content
@@ -19,21 +56,21 @@ audit_git_version: "benchmark_{{ benchmark_version }}"
 audit_conf_dir: "{{ audit_conf_dest | default('/opt') }}/{{ benchmark }}-Audit"
 
 # If changed these can affect other products
-pre_audit_outfile: "{{ audit_log_dir }}/{{ ansible_facts.hostname }}-{{ benchmark }}-{{ benchmark_version }}_pre_scan_{{ ansible_facts.date_time.epoch }}.{{ audit_format }}"
-post_audit_outfile: "{{ audit_log_dir }}/{{ ansible_facts.hostname }}-{{ benchmark }}-{{ benchmark_version }}_post_scan_{{ ansible_facts.date_time.epoch }}.{{ audit_format }}"
+pre_audit_outfile: "{{ audit_log_dir }}/{{ ansible_facts['hostname'] }}-{{ benchmark }}-{{ benchmark_version }}_pre_scan_{{ ansible_facts['date_time']['epoch'] }}.{{ audit_format }}"
+post_audit_outfile: "{{ audit_log_dir }}/{{ ansible_facts['hostname'] }}-{{ benchmark }}-{{ benchmark_version }}_post_scan_{{ ansible_facts['date_time']['epoch'] }}.{{ audit_format }}"
 
 ## The following should not need changing
 
 ### Audit binary settings ###
 audit_bin_version:
-  release: v0.4.8
-  AMD64_checksum: 'sha256:85d00b7bba5f175bec95de7dfe1f71f8f25204914aad4c6f03c8457868eb6e2f'
-  ARM64_checksum: 'sha256:bca8c898bfd35b94c51455ece6193c95e2cd7b2b183ac2047b2d76291e73e47d'
+  release: v0.5.0
+  AMD64_checksum: 'sha256:1371df12806586e4c6b122a22e1dbc2b9008160099eaf2816d139cc825ffc40a'
+  ARM64_checksum: 'sha256:d34fae1b2e33bbe2f461418891c88dd636f212a0a2d4bb0601111a8dfa09efa2'
 audit_bin_path: /usr/local/bin/
 audit_bin: "{{ audit_bin_path }}goss"
 audit_format: json
 
-audit_vars_path: "{{ audit_conf_dir }}/vars/{{ ansible_facts.hostname }}.yml"
+audit_vars_path: "{{ audit_conf_dir }}/vars/{{ ansible_facts['hostname'] }}.yml"
 audit_results: |
   The{% if not audit_only %} pre remediation{% endif %} audit results are: {{ pre_audit_results }}
   {% if not audit_only %}The post remediation audit results are: {{ post_audit_results }}{% endif %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -9,6 +9,9 @@ change_requires_reboot: false
 # 'false' is left unchanged.
 system_is_container: false
 
+# Set default facts
+ubtu24cis_apparmor_enforce_only: false
+
 # Used to control warning summary
 warn_control_list: ""
 warn_count: 0


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
Latest updates and improvements across multiple repos
issues and PRs addressed


- tasks/section_2/cis_2.1.x.yml line 642: Corrected service name typo `ngnix.service` to `nginx.service`
- defaults/main.yml: Set `audit_run_heavy_tests` default to `false` (opt-in convention — avoids slow tests in CI by default)
- defaults/main.yml: Moved 7 internal audit constants to `vars/audit.yml` where they belong (`audit_max_concurrent`, `get_audit_binary_method`, `audit_bin_copy_location`, `audit_content`, `audit_conf_source`, `audit_conf_dest`, `audit_log_dir`) — these are role implementation details that should not be user-overridable
- vars/CIS.yml (audit repo): Corrected `benchmark_version` from `2.0.0` to `1.0.0`
- molecule/localhost/converge.yml, molecule/wsl/converge.yml: Added `setup_audit: true` and `run_audit: true` so molecule runs the full audit on converge
- .github/workflows/export_badges_public.yml: Removed — this workflow is for public mirrors only and must not be present in a private repo
- CONTRIBUTING.md: Added — was missing from remediation repo
- 15 manual controls: Changed tag from `patch` to `audit` — these controls require manual intervention and must not perform active remediation: 1.1.1.10, 1.2.2.1, 3.1.1, 4.2.5, 4.4.2.3, 4.4.3.3, 5.3.3.2.3, 5.4.1.2, 6.1.1.3, 6.1.2.1.2, 6.1.3.5, 6.1.3.6, 6.1.3.8, 6.2.3.21
- updated 1.1.1.10 to be able to set location the script runs from
- ability to change default shell for shell module calls
- Converted ansible dot-notation references to bracket notation
- improved 5.2.4 tests and prelim check
- aligned audit variable naming wih remediation vars
- removed unneeded handlers
- tidy up audit variables
- Thanks to @bykvaadm
  - #157 PAM update
  - #168 sshd fix
  - #169 bootloader file permissions also thanks to @alexmroke
  - #176 dot file. excludion addition 7.2.10
- Thanks to seven-beep
  - #171 os_check addition
- thanks to @dderemiah
  - #167 pam improvements
- thanks to @hackery
  - #175 overlay mod change 1.1.1.6
- thanks to @defnotyujine
  - tmp mount handler changed to import_tasks
- 100 task files: Converted `ansible_facts` dot notation to bracket notation throughout `tasks/` and `vars/`
- Added `set -o pipefail` and `args: executable: /bin/bash` to tasks with pipes
- templates/ansible_vars_goss.yml.j2: Renamed to `templates/lockdown_audit.yml.j2`  updated reference in `tasks/

**How has this been tested?:**
Please give an overview of how these changes were tested. If they were not please use N/A

