### PR TITLE
Fix 4.3.4 comment character placement

### DIFF
--- a/tasks/section_4/cis_4.3.x.yml
+++ b/tasks/section_4/cis_4.3.x.yml
@@ -97,7 +97,7 @@
         msg: "Warning!! NFTables is not supported in this role. Please use UFW, iptables, or manually manage nftables | Message out warning"
         # ansible.builtin.shell: "nft create table {{ ubtu24cis_nftables_table_name }}"
         # changed_when: discovered_new_nftable.rc == 0
-        failed_when: #  discovered_new_nftable.rc not in [0, 1]
+        # failed_when: discovered_new_nftable.rc not in [0, 1]
         # check_mode: false
         # register: discovered_new_nftable
 


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
At the 4.3.4 section a comment character was placed at the wrong spot. Failed_when is not an option at the debug module.

**Issue Fixes:**
No open issue, direct fix.

**Enhancements:**
None.

**How has this been tested?:**
Placed the comment character at the right spot (before the failed_when) and ran the task again.

