### PR TITLE
5.3.x remove header and blank lines from pam-configs templates as pam-auth-update does not support/cater for these yet

### DIFF
--- a/templates/usr/share/pam-configs/faillock.j2
+++ b/templates/usr/share/pam-configs/faillock.j2
@@ -1,5 +1,3 @@
-{{ file_managed_by_ansible }}
-
 Name: Enable pam_faillock to deny access
 Default: yes
 Priority: 0

--- a/templates/usr/share/pam-configs/faillock_notify.j2
+++ b/templates/usr/share/pam-configs/faillock_notify.j2
@@ -1,5 +1,3 @@
-{{ file_managed_by_ansible }}
-
 Name: Notify of failed login attempts and reset count upon success
 Default: yes
 Priority: 1024

--- a/templates/usr/share/pam-configs/pam_unix.j2
+++ b/templates/usr/share/pam-configs/pam_unix.j2
@@ -1,5 +1,3 @@
-{{ file_managed_by_ansible }}
-
 Name: Unix authentication
 Default: yes
 Priority: 256

--- a/templates/usr/share/pam-configs/pwhistory.j2
+++ b/templates/usr/share/pam-configs/pwhistory.j2
@@ -1,5 +1,3 @@
-{{ file_managed_by_ansible }}
-
 Name: pwhistory password history checking
 Default: yes
 Priority: 1024

--- a/templates/usr/share/pam-configs/pwquality.j2
+++ b/templates/usr/share/pam-configs/pwquality.j2
@@ -1,5 +1,3 @@
-{{ file_managed_by_ansible }}
-
 Name: Pwquality password strength checking
 Default: yes
 Priority: 1024


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**

Remove header (with comments) and blank lines from `pam-configs` templates as `pam-auth-update` does not support/cater for these yet (https://bugs.launchpad.net/ubuntu/+source/pam/+bug/2075508)

**Issue Fixes:**

#188 

**Enhancements:**

N/A

**How has this been tested?:**

Tested manually by applying role with offending lines in templates removed, then running `pam-auth-update` for respective pam module to confirm it no longer generates errors similar to below (which occur when the pam configs have comments and/or blank lines.

```
Use of uninitialized value $fieldname in hash element at /usr/sbin/pam-auth-update line 734, <PROFILE> line 1.
Use of uninitialized value in pattern match (m//) at /usr/sbin/pam-auth-update line 734, <PROFILE> line 1.
```
