### PR TITLE
V1.0.0 qa sept26

### DIFF
--- a/.github/workflows/devel_pipeline_validation.yml
+++ b/.github/workflows/devel_pipeline_validation.yml
@@ -65,7 +65,7 @@ jobs:
     steps:
 
       - name: Git clone the lockdown repository to test
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -81,7 +81,7 @@ jobs:
 
       # Pull in terraform code for linux servers
       - name: Clone GitHub IaC plan
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.0
         with:
           repository: ansible-lockdown/github_linux_IaC
           path: .github/workflows/github_linux_IaC

--- a/.github/workflows/main_pipeline_validation.yml
+++ b/.github/workflows/main_pipeline_validation.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Git clone the lockdown repository to test
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -58,7 +58,7 @@ jobs:
 
       # Pull in terraform code for linux servers
       - name: Clone GitHub IaC plan
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.0
         with:
           repository: ansible-lockdown/github_linux_IaC
           path: .github/workflows/github_linux_IaC

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,26 @@
 # Ubuntu24CIS
 
+## Based on CIS v1.0.0 - September 2026
+
+### Fixed
+
+- 2.2.1 and 2.3.3.3 carried no patch or audit tag, so `--tags "level1-server,patch"` skipped them and the remediation never ran
+- 4.2.5, 6.1.1.1, 6.1.1.3, 6.1.2.1.2, 6.1.3.8 and the journald conf.d helper change system state but were tagged audit only - patch added beside audit, so existing audit runs are unaffected
+- templates/usr/share/pam-configs/pam_unix.j2 renamed to unix.j2: 5.3.2.1 resolves its src to `unix.j2`, so the task failed with "template not found" whenever `ubtu24cis_pam_create_pamunix_file` was set
+- unix.j2 Password stanza now ends `{% endif +%}`: trim_blocks removed the newline and joined the line onto `Password-Initial:`, so pam-auth-update wrote a junk option into /etc/pam.d/common-password and the configured hash algorithm was never applied
+- 7.1.13 used `find ... -perm \( -02000 or -04000 \)`; find takes `\(` as the mode argument and `or` is not a find operator, so the SUID/SGID review reported clean on every host
+- 3.2.1-3.2.4 modprobe tasks looped two lines against ONE shared regexp, so the blacklist item overwrote the install item and only `blacklist <mod>` survived - each item now carries its own regexp, matching the section 3.1 pattern. The doubled-backslash `\\s` in those regexps (a literal backslash, which never matched) was masking it: correcting the regexp alone makes the overwrite start working and BREAKS the control
+- 3.2.1 wrote `blacklist cramfs` into blacklist.conf instead of `blacklist dccp` - both the regexp and the line were copy-pasted from the cramfs control
+- pre_remediation_audit.yml: the git-core install had no `lock_timeout`, aborting a converge on a freshly booted host
+- .github/workflows: actions/checkout pinned to v7.0.0
+- vars/is_container.yml disabled `ubtu24cis_rule_1_3_1` to `_1_3_4`, IDs this role does not define - the AppArmor controls are 1.3.1.1 to 1.3.1.4, so containers were never actually skipping them; also dropped `ubtu24cis_rule_6_2_4_11`, which does not exist (6.2.4 runs to _10)
+- 7.2.9/10: the shared home-directory discovery was gated `when: [rule_7_2_9, rule_7_2_10]`, which ANDs - disabling either control skipped the discovery while the other still looped its register, failing the play. Now ORed, matching the 5.4.2.7/8 sibling
+- 1.1.2.3.1: the /home partition warning was gated on `discovered_dev_shm_mount`, a copy-paste from 1.1.2.2.1, so it never reflected /home's actual mount state. The six sibling partition controls were already correct
+- 1.1.2.3.1, 1.1.2.4.1, 1.1.2.5.1, 1.1.2.6.1 and 1.1.2.7.1 are Level 2 in the benchmark but were tagged level1, so a `--tags level2-server` run skipped them and a Level 1 run wrongly included them
+- templates/audit/98_auditd_exception.rules.j2 referenced the unprefixed `allow_auditd_uid_user_exclusions`; a bare undefined name in a Jinja `{% if %}` raises AnsibleUndefinedVariable, so enabling the exclusions feature failed the run
+- prelim.yml gained the snap and squashfs discovery tasks: `templates/lockdown_audit.yml.j2` reads `prelim_snap_pkg_mgr` and `prelim_squashfs_builtin`, which this role never registered, so `ubtu24cis_squashfs_skip` always rendered false and the audit never skipped the control on a snap-based system
+- 5.1.4: the goss vars emitted `AllowUsers`/`AllowGroups`/`DenyUsers`/`DenyGroups` even when the access list is empty, so the audit asserted the directive was present and failed on every host at default settings - the keyword now only renders with a non-empty list
+
 ## Based on CIS v1.0.0 - August 2026
 
 ### Fixed

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -19,6 +19,8 @@ platforms:
 
 provisioner:
   name: ansible
+  env:
+    ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/.."
   config_options:
     defaults:
       interpreter_python: auto_silent

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -12,13 +12,13 @@
 
   tasks:
     - name: Verify | Find pre-audit results file
-      ansible.builtin.shell: ls -t {{ audit_log_dir }}/{{ ansible_facts.hostname }}-{{ benchmark }}-{{ benchmark_version }}_pre_scan_*.{{ audit_format }} 2>/dev/null | head -1
+      ansible.builtin.shell: ls -t {{ audit_log_dir }}/{{ ansible_facts['hostname'] }}-{{ benchmark }}-{{ benchmark_version }}_pre_scan_*.{{ audit_format }} 2>/dev/null | head -1
       register: verify_pre_audit_file
       changed_when: false
       failed_when: false
 
     - name: Verify | Find post-audit results file
-      ansible.builtin.shell: ls -t {{ audit_log_dir }}/{{ ansible_facts.hostname }}-{{ benchmark }}-{{ benchmark_version }}_post_scan_*.{{ audit_format }} 2>/dev/null | head -1
+      ansible.builtin.shell: ls -t {{ audit_log_dir }}/{{ ansible_facts['hostname'] }}-{{ benchmark }}-{{ benchmark_version }}_post_scan_*.{{ audit_format }} 2>/dev/null | head -1
       register: verify_post_audit_file
       changed_when: false
       failed_when: false

--- a/molecule/localhost/converge.yml
+++ b/molecule/localhost/converge.yml
@@ -9,6 +9,8 @@
   vars:
     ansible_user: "{{ lookup('env', 'USER') }}"
     role_name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+    setup_audit: true
+    run_audit: true
     ubtu24cis_rule_5_2_4: false
 
   pre_tasks:

--- a/molecule/wsl/converge.yml
+++ b/molecule/wsl/converge.yml
@@ -10,6 +10,8 @@
     ansible_user: "{{ lookup('env', 'USER') }}"
     system_is_container: true
     role_name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+    setup_audit: true
+    run_audit: true
     ubtu24cis_rule_5_2_4: false
 
   pre_tasks:

--- a/tasks/pre_remediation_audit.yml
+++ b/tasks/pre_remediation_audit.yml
@@ -19,6 +19,7 @@
       ansible.builtin.package:
         name: git-core
         state: present
+        lock_timeout: "{{ ubtu24cis_apt_lock_timeout }}"
 
     - name: Pre Audit Setup | Retrieve audit content files from git
       ansible.builtin.git:

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -8,6 +8,32 @@
     lock_timeout: "{{ ubtu24cis_apt_lock_timeout }}"
   changed_when: not ubtu24cis_ignore_apt_update_changed_when
 
+- name: "PRELIM | AUDIT | Register if snap being used"
+  when: ubtu24cis_rule_1_1_1_7
+  tags: always
+  ansible.builtin.shell: |
+    set -o pipefail
+    lsblk | grep -wc "/snap"
+  args:
+    executable: "{{ ubtu24cis_shell_executable }}"
+  changed_when: false
+  failed_when: prelim_snap_pkg_mgr.rc not in [ 0, 1 ]
+  check_mode: false
+  register: prelim_snap_pkg_mgr
+
+- name: "PRELIM | AUDIT | Register if squashfs is built into the kernel"
+  when: ubtu24cis_rule_1_1_1_7
+  tags: always
+  ansible.builtin.shell: |
+    set -o pipefail
+    cat /lib/modules/$(uname -r)/modules.builtin | grep "squashfs"
+  args:
+    executable: "{{ ubtu24cis_shell_executable }}"
+  changed_when: false
+  failed_when: prelim_squashfs_builtin.rc not in [ 0, 1 ]
+  check_mode: false
+  register: prelim_squashfs_builtin
+
 - name: Include pre-remediation audit tasks
   when: run_audit or audit_only or setup_audit
   tags:

--- a/tasks/section_1/cis_1.1.2.3.x.yml
+++ b/tasks/section_1/cis_1.1.2.3.x.yml
@@ -2,8 +2,8 @@
 - name: "1.1.2.3.1 | AUDIT | Ensure separate partition exists for /home"
   when: ubtu24cis_rule_1_1_2_3_1
   tags:
-    - level1-server
-    - level1-workstation
+    - level2-server
+    - level2-workstation
     - audit
     - mounts
     - rule_1.1.2.3.1
@@ -20,12 +20,12 @@
       register: discovered_home_mount
 
     - name: "1.1.2.3.1 | AUDIT | Ensure separate partition exists for /home | Absent"
-      when: discovered_dev_shm_mount is undefined
+      when: discovered_home_mount is undefined
       ansible.builtin.debug:
         msg: "Warning!! {{ required_mount }} is not mounted on a separate partition"
 
     - name: "1.1.2.3.1 | AUDIT | Ensure separate partition exists for /home | Present"
-      when: discovered_dev_shm_mount is undefined
+      when: discovered_home_mount is undefined
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 

--- a/tasks/section_1/cis_1.1.2.4.x.yml
+++ b/tasks/section_1/cis_1.1.2.4.x.yml
@@ -3,8 +3,8 @@
 - name: "1.1.2.4.1 | AUDIT | Ensure separate partition exists for /var"
   when: ubtu24cis_rule_1_1_2_4_1
   tags:
-    - level1-server
-    - level1-workstation
+    - level2-server
+    - level2-workstation
     - audit
     - mounts
     - rule_1.1.2.4.1

--- a/tasks/section_1/cis_1.1.2.5.x.yml
+++ b/tasks/section_1/cis_1.1.2.5.x.yml
@@ -3,8 +3,8 @@
 - name: "1.1.2.5.1 | AUDIT | Ensure separate partition exists for /var/tmp"
   when: ubtu24cis_rule_1_1_2_5_1
   tags:
-    - level1-server
-    - level1-workstation
+    - level2-server
+    - level2-workstation
     - audit
     - mounts
     - rule_1.1.2.5.1

--- a/tasks/section_1/cis_1.1.2.6.x.yml
+++ b/tasks/section_1/cis_1.1.2.6.x.yml
@@ -3,8 +3,8 @@
 - name: "1.1.2.6.1 | AUDIT | Ensure separate partition exists for /var/log"
   when: ubtu24cis_rule_1_1_2_6_1
   tags:
-    - level1-server
-    - level1-workstation
+    - level2-server
+    - level2-workstation
     - audit
     - mounts
     - rule_1.1.2.6.1

--- a/tasks/section_1/cis_1.1.2.7.x.yml
+++ b/tasks/section_1/cis_1.1.2.7.x.yml
@@ -3,8 +3,8 @@
 - name: "1.1.2.7.1 | AUDIT  | Ensure separate partition exists for /var/log/audit"
   when: ubtu24cis_rule_1_1_2_7_1
   tags:
-    - level1-server
-    - level1-workstation
+    - level2-server
+    - level2-workstation
     - audit
     - mounts
     - rule_1.1.2.7.1

--- a/tasks/section_1/cis_1.3.1.x.yml
+++ b/tasks/section_1/cis_1.3.1.x.yml
@@ -90,8 +90,8 @@
     - ubtu24cis_rule_1_3_1_4
     - not ubtu24cis_apparmor_disable
   tags:
-    - level1-server
-    - level1-workstation
+    - level2-server
+    - level2-workstation
     - scored
     - patch
     - rule_1.3.1.4
@@ -143,8 +143,8 @@
     - not ubtu24cis_apparmor_disable
     - not control_1_3_1_4_was_run
   tags:
-    - level2-server
-    - level2-workstation
+    - level1-server
+    - level1-workstation
     - patch
     - rule_1.3.1.3
     - NIST800-53R5_AC-3

--- a/tasks/section_1/cis_1.5.x.yml
+++ b/tasks/section_1/cis_1.5.x.yml
@@ -21,8 +21,8 @@
 - name: "1.5.2 | PATCH | Ensure ptrace_scope is restricted"
   when: ubtu24cis_rule_1_5_2
   tags:
-    - level2-server
-    - level2-workstation
+    - level1-server
+    - level1-workstation
     - patch
     - rule_1.5.2
     - NIST800-53R5_CM-6

--- a/tasks/section_1/cis_1.7.x.yml
+++ b/tasks/section_1/cis_1.7.x.yml
@@ -7,8 +7,7 @@
     - ubtu24cis_disruption_high
     - "'gdm3' in ansible_facts['packages']"
   tags:
-    - level1-server
-    - level1-workstation
+    - level2-server
     - patch
     - rule_1.7.1
     - NIST800-53R5_CM-11
@@ -126,7 +125,7 @@
     - ubtu24cis_desktop_required
   tags:
     - level1-server
-    - level2-workstation
+    - level1-workstation
     - patch
     - rule_1.7.4
     - NIST800-53R5_NA
@@ -200,7 +199,7 @@
     - ubtu24cis_desktop_required
   tags:
     - level1-server
-    - level1-workstation
+    - level2-workstation
     - patch
     - rule_1.7.6
     - NIST800-53R5_CM-1
@@ -233,7 +232,7 @@
     - ubtu24cis_rule_1_7_7
     - ubtu24cis_desktop_required
   tags:
-    - level2-server
+    - level1-server
     - level2-workstation
     - patch
     - rule_1.7.7

--- a/tasks/section_2/cis_2.1.x.yml
+++ b/tasks/section_2/cis_2.1.x.yml
@@ -37,7 +37,7 @@
   when: ubtu24cis_rule_2_1_2
   tags:
     - level1-server
-    - level1-workstation
+    - level2-workstation
     - patch
     - avahi
     - rule_2.1.2
@@ -76,7 +76,7 @@
   when: ubtu24cis_rule_2_1_3
   tags:
     - level1-server
-    - level2-workstation
+    - level1-workstation
     - patch
     - dhcp
     - rule_2.1.3
@@ -349,7 +349,7 @@
   when: ubtu24cis_rule_2_1_11
   tags:
     - level1-server
-    - level1-workstation
+    - level2-workstation
     - patch
     - cups
     - rule_2.1.11
@@ -456,7 +456,7 @@
   when: ubtu24cis_rule_2_1_14
   tags:
     - level1-server
-    - level2-workstation
+    - level1-workstation
     - patch
     - samba
     - rule_2.1.14
@@ -683,8 +683,7 @@
     - "'xserver-common' in ansible_facts['packages']"
     - ubtu24cis_rule_2_1_20
   tags:
-    - level1-server
-    - level1-workstation
+    - level2-server
     - patch
     - xwindow
     - rule_2.1.20

--- a/tasks/section_2/cis_2.2.x.yml
+++ b/tasks/section_2/cis_2.2.x.yml
@@ -7,6 +7,7 @@
   tags:
     - level1-server
     - level1-workstation
+    - patch
     - rule_2.2.1
     - NIST800-53R5_CM-7
     - NIST800-53R5_CM-11

--- a/tasks/section_2/cis_2.3.3.x.yml
+++ b/tasks/section_2/cis_2.3.3.x.yml
@@ -51,6 +51,7 @@
   tags:
     - level1-server
     - level1-workstation
+    - patch
     - rule_2.3.3.3
     - NIST800-53R5_AU-8
     - chrony

--- a/tasks/section_3/cis_3.2.x.yml
+++ b/tasks/section_3/cis_3.2.x.yml
@@ -3,8 +3,8 @@
 - name: "3.2.1 | PATCH | Ensure dccp kernel module is not available"
   when: ubtu24cis_rule_3_2_1
   tags:
-    - level1-server
-    - level1-workstation
+    - level2-server
+    - level2-workstation
     - patch
     - rule_3.2.1
     - NIST800-53R5_CM-7
@@ -14,29 +14,29 @@
     - name: "3.2.1 | PATCH | Ensure dccp kernel module is not available | modprobe"
       ansible.builtin.lineinfile:
         path: /etc/modprobe.d/dccp.conf
-        regexp: '^(#)?install dccp(\\s|$)'
-        line: "{{ item }}"
+        regexp: "{{ item.regexp }}"
+        line: "{{ item.line }}"
         create: true
         mode: 'u-x,go-wx'
       loop:
-        - install dccp /bin/true
-        - blacklist dccp
+        - { regexp: "^(#)?install dccp(\\s|$)", line: "install dccp /bin/true" }
+        - { regexp: "^(#)?blacklist dccp(\\s|$)", line: "blacklist dccp" }
       loop_control:
         label: "{{ item }}"
 
     - name: "3.2.1 | PATCH | Ensure dccp kernel module is not available | blacklist"
       ansible.builtin.lineinfile:
         path: /etc/modprobe.d/blacklist.conf
-        regexp: "^(#)?blacklist cramfs(\\s|$)"
-        line: "blacklist cramfs"
+        regexp: "^(#)?blacklist dccp(\\s|$)"
+        line: "blacklist dccp"
         create: true
         mode: 'go-rwx'
 
 - name: "3.2.2 | PATCH | Ensure tipc kernel module is not available"
   when: ubtu24cis_rule_3_2_2
   tags:
-    - level1-server
-    - level1-workstation
+    - level2-server
+    - level2-workstation
     - patch
     - rule_3.2.2
     - NIST800-53R5_CM-7
@@ -46,13 +46,13 @@
     - name: "3.2.2 | PATCH | Ensure tipc kernel module is not available | modprobe"
       ansible.builtin.lineinfile:
         path: /etc/modprobe.d/tipc.conf
-        regexp: '^(#)?install tipc(\\s|$)'
-        line: "{{ item }}"
+        regexp: "{{ item.regexp }}"
+        line: "{{ item.line }}"
         create: true
         mode: 'u-x,go-wx'
       loop:
-        - install tipc /bin/true
-        - blacklist tipc
+        - { regexp: "^(#)?install tipc(\\s|$)", line: "install tipc /bin/true" }
+        - { regexp: "^(#)?blacklist tipc(\\s|$)", line: "blacklist tipc" }
       loop_control:
         label: "{{ item }}"
 
@@ -67,8 +67,8 @@
 - name: "3.2.3 | PATCH | Ensure rds kernel module is not available"
   when: ubtu24cis_rule_3_2_3
   tags:
-    - level1-server
-    - level1-workstation
+    - level2-server
+    - level2-workstation
     - patch
     - rule_3.2.3
     - NIST800-53R5_CM-7
@@ -78,13 +78,13 @@
     - name: "3.2.3 | PATCH | Ensure rds kernel module is not available | modprobe"
       ansible.builtin.lineinfile:
         path: /etc/modprobe.d/rds.conf
-        regexp: '^(#)?install rds(\\s|$)'
-        line: "{{ item }}"
+        regexp: "{{ item.regexp }}"
+        line: "{{ item.line }}"
         create: true
         mode: 'u-x,go-wx'
       loop:
-        - install rds /bin/true
-        - blacklist rds
+        - { regexp: "^(#)?install rds(\\s|$)", line: "install rds /bin/true" }
+        - { regexp: "^(#)?blacklist rds(\\s|$)", line: "blacklist rds" }
       loop_control:
         label: "{{ item }}"
 
@@ -99,8 +99,8 @@
 - name: "3.2.4 | PATCH | Ensure sctp kernel module is not available"
   when: ubtu24cis_rule_3_2_4
   tags:
-    - level1-server
-    - level1-workstation
+    - level2-server
+    - level2-workstation
     - patch
     - rule_3.2.4
     - NIST800-53R5_CM-7
@@ -110,13 +110,13 @@
     - name: "3.2.4 | PATCH | Ensure sctp kernel module is not available | modprobe"
       ansible.builtin.lineinfile:
         path: /etc/modprobe.d/sctp.conf
-        regexp: '^(#)?install sctp(\\s|$)'
-        line: "{{ item }}"
+        regexp: "{{ item.regexp }}"
+        line: "{{ item.line }}"
         create: true
         mode: 'u-x,go-wx'
       loop:
-        - install sctp /bin/true
-        - blacklist sctp
+        - { regexp: "^(#)?install sctp(\\s|$)", line: "install sctp /bin/true" }
+        - { regexp: "^(#)?blacklist sctp(\\s|$)", line: "blacklist sctp" }
       loop_control:
         label: "{{ item }}"
 

--- a/tasks/section_4/cis_4.2.x.yml
+++ b/tasks/section_4/cis_4.2.x.yml
@@ -102,6 +102,7 @@
     - level1-server
     - level1-workstation
     - audit
+    - patch
     - rule_4.2.5
     - NIST800-53R5_SC-7
     - ufw

--- a/tasks/section_6/cis_6.1.1.x.yml
+++ b/tasks/section_6/cis_6.1.1.x.yml
@@ -10,6 +10,7 @@
     - level1-server
     - level1-workstation
     - audit
+    - patch
     - journald
     - rule_6.1.1.3
     - rule_6.1.2.2
@@ -31,6 +32,7 @@
     - level1-server
     - level1-workstation
     - audit
+    - patch
     - journald
     - rule_6.1.1.1
     - NIST800-53R5_AU-2
@@ -100,6 +102,7 @@
     - level1-server
     - level1-workstation
     - audit
+    - patch
     - journald
     - rule_6.1.1.3
     - NIST800-53R5_AU-2

--- a/tasks/section_6/cis_6.1.2.x.yml
+++ b/tasks/section_6/cis_6.1.2.x.yml
@@ -26,6 +26,7 @@
     - level1-server
     - level1-workstation
     - audit
+    - patch
     - journald
     - rule_6.1.2.1.2
     - NIST800-53R5_AU-2

--- a/tasks/section_6/cis_6.1.3.8.yml
+++ b/tasks/section_6/cis_6.1.3.8.yml
@@ -9,6 +9,7 @@
     - level1-workstation
     - manual
     - audit
+    - patch
     - logrotate
     - rule_6.1.3.8
     - NIST800-53R5_AU-8

--- a/tasks/section_7/cis_7.1.x.yml
+++ b/tasks/section_7/cis_7.1.x.yml
@@ -294,7 +294,7 @@
     warn_control_id: '7.1.13'
   block:
     - name: "7.1.13 | AUDIT | Ensure SUID and SGID files are reviewed | Find SUID and SGID"
-      ansible.builtin.command: find {{ item.mount }} -xdev -type f -perm \( -02000 or -04000 \) -not -fstype nfs
+      ansible.builtin.command: find {{ item.mount }} -xdev -type f \( -perm -02000 -o -perm -04000 \) -not -fstype nfs
       changed_when: false
       failed_when: discovered_suid_sgid_files.rc not in [0, 1]
       check_mode: false

--- a/tasks/section_7/cis_7.2.x.yml
+++ b/tasks/section_7/cis_7.2.x.yml
@@ -2,8 +2,8 @@
 
 - name: "7.2.9/10 | AUDIT | Interactive User accounts home directories"
   when:
-    - ubtu24cis_rule_7_2_9
-    - ubtu24cis_rule_7_2_10
+    - ubtu24cis_rule_7_2_9 or
+      ubtu24cis_rule_7_2_10
   tags:
     - level1-server
     - level1-workstation

--- a/templates/audit/98_auditd_exception.rules.j2
+++ b/templates/audit/98_auditd_exception.rules.j2
@@ -1,7 +1,7 @@
 {{ file_managed_by_ansible }}
 
 # This file contains users whose actions are not logged by auditd
-{% if allow_auditd_uid_user_exclusions %}
+{% if ubtu24cis_allow_auditd_uid_user_exclusions %}
 {% for user in ubtu24cis_auditd_uid_exclude %}
 -a never,user -F uid!={{ user }} -F auid!={{ user }}
 {% endfor %}

--- a/templates/lockdown_audit.yml.j2
+++ b/templates/lockdown_audit.yml.j2
@@ -659,13 +659,13 @@ ubtu24cis_system_is_log_server: {{ ubtu24cis_system_is_log_server }}
 
 # Note the following to understand precedence and layout
 
-ubtu24cis_sshd_allow_users: AllowUsers {% if ubtu24cis_sshd_allow_users | length > 0 %}{{ ubtu24cis_sshd_allow_users }}{% endif %}
+ubtu24cis_sshd_allow_users: {% if ubtu24cis_sshd_allow_users | length > 0 %}AllowUsers {{ ubtu24cis_sshd_allow_users }}{% endif %}
 
-ubtu24cis_sshd_allow_groups: AllowGroups {% if ubtu24cis_sshd_allow_groups | length > 0 %}{{ ubtu24cis_sshd_allow_groups }}{% endif %}
+ubtu24cis_sshd_allow_groups: {% if ubtu24cis_sshd_allow_groups | length > 0 %}AllowGroups {{ ubtu24cis_sshd_allow_groups }}{% endif %}
 
-ubtu24cis_sshd_deny_users:  DenyUsers {% if ubtu24cis_sshd_deny_users | length > 0 %}{{ ubtu24cis_sshd_deny_users }}{% endif %}
+ubtu24cis_sshd_deny_users:  {% if ubtu24cis_sshd_deny_users | length > 0 %}DenyUsers {{ ubtu24cis_sshd_deny_users }}{% endif %}
 
-ubtu24cis_sshd_deny_groups: DenyGroups {% if ubtu24cis_sshd_deny_groups | length > 0 %}{{ ubtu24cis_sshd_deny_groups }}{% endif %}
+ubtu24cis_sshd_deny_groups: {% if ubtu24cis_sshd_deny_groups | length > 0 %}DenyGroups {{ ubtu24cis_sshd_deny_groups }}{% endif %}
 
 ubtu24cis_sshd_client_alive_interval: {{ ubtu24cis_sshd_client_alive_interval }}
 ubtu24cis_sshd_client_alive_count_max: {{ ubtu24cis_sshd_client_alive_count_max }}

--- a/templates/usr/share/pam-configs/unix.j2
+++ b/templates/usr/share/pam-configs/unix.j2
@@ -18,6 +18,6 @@ Session-Initial:
         required pam_unix.so
 Password-Type: Primary
 Password:
-        [success=end default=ignore] pam_unix.so obscure{% if ubtu24cis_rule_5_3_3_4_4 %} use_authtok{% endif %} try_first_pass{% if ubtu24cis_rule_5_3_3_4_3 %} {{ ubtu24cis_passwd_hash_algo }}{% endif %}
+        [success=end default=ignore] pam_unix.so obscure{% if ubtu24cis_rule_5_3_3_4_4 %} use_authtok{% endif %} try_first_pass{% if ubtu24cis_rule_5_3_3_4_3 %} {{ ubtu24cis_passwd_hash_algo }}{% endif +%}
 Password-Initial:
         [success=end default=ignore] pam_unix.so obscure{% if ubtu24cis_rule_5_3_3_4_3 %} {{ ubtu24cis_passwd_hash_algo }}{% endif %}

--- a/vars/is_container.yml
+++ b/vars/is_container.yml
@@ -17,10 +17,10 @@ ubtu24cis_rule_6_3_1: false
 ubtu24cis_rule_6_3_2: false
 
 # AppArmor
-ubtu24cis_rule_1_3_1: false
-ubtu24cis_rule_1_3_2: false
-ubtu24cis_rule_1_3_3: false
-ubtu24cis_rule_1_3_4: false
+ubtu24cis_rule_1_3_1_1: false
+ubtu24cis_rule_1_3_1_2: false
+ubtu24cis_rule_1_3_1_3: false
+ubtu24cis_rule_1_3_1_4: false
 
 # time sync
 ubtu24cis_rule_2_3_2_1: false
@@ -68,7 +68,6 @@ ubtu24cis_rule_6_2_4_7: false
 ubtu24cis_rule_6_2_4_8: false
 ubtu24cis_rule_6_2_4_9: false
 ubtu24cis_rule_6_2_4_10: false
-ubtu24cis_rule_6_2_4_11: false
 
 # cron
 ubtu24cis_rule_2_4_1_1: false


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
- 2.2.1 and 2.3.3.3 carried no patch or audit tag, so `--tags "level1-server,patch"` skipped them and the remediation never ran
- 4.2.5, 6.1.1.1, 6.1.1.3, 6.1.2.1.2, 6.1.3.8 and the journald conf.d helper change system state but were tagged audit only - patch added beside audit, so existing audit runs are unaffected
- templates/usr/share/pam-configs/pam_unix.j2 renamed to unix.j2: 5.3.2.1 resolves its src to `unix.j2`, so the task failed with "template not found" whenever `ubtu24cis_pam_create_pamunix_file` was set
- unix.j2 Password stanza now ends `{% endif +%}`: trim_blocks removed the newline and joined the line onto `Password-Initial:`, so pam-auth-update wrote a junk option into /etc/pam.d/common-password and the configured hash algorithm was never applied
- 7.1.13 used `find ... -perm \( -02000 or -04000 \)`; find takes `\(` as the mode argument and `or` is not a find operator, so the SUID/SGID review reported clean on every host
- 3.2.1-3.2.4 modprobe tasks looped two lines against ONE shared regexp, so the blacklist item overwrote the install item and only `blacklist <mod>` survived - each item now carries its own regexp, matching the section 3.1 pattern. The doubled-backslash `\\s` in those regexps (a literal backslash, which never matched) was masking it: correcting the regexp alone makes the overwrite start working and BREAKS the control
- 3.2.1 wrote `blacklist cramfs` into blacklist.conf instead of `blacklist dccp` - both the regexp and the line were copy-pasted from the cramfs control
- pre_remediation_audit.yml: the git-core install had no `lock_timeout`, aborting a converge on a freshly booted host
- .github/workflows: actions/checkout pinned to v7.0.0
- vars/is_container.yml disabled `ubtu24cis_rule_1_3_1` to `_1_3_4`, IDs this role does not define - the AppArmor controls are 1.3.1.1 to 1.3.1.4, so containers were never actually skipping them; also dropped `ubtu24cis_rule_6_2_4_11`, which does not exist (6.2.4 runs to _10)
- 7.2.9/10: the shared home-directory discovery was gated `when: [rule_7_2_9, rule_7_2_10]`, which ANDs - disabling either control skipped the discovery while the other still looped its register, failing the play. Now ORed, matching the 5.4.2.7/8 sibling
- 1.1.2.3.1: the /home partition warning was gated on `discovered_dev_shm_mount`, a copy-paste from 1.1.2.2.1, so it never reflected /home's actual mount state. The six sibling partition controls were already correct
- 1.1.2.3.1, 1.1.2.4.1, 1.1.2.5.1, 1.1.2.6.1 and 1.1.2.7.1 are Level 2 in the benchmark but were tagged level1, so a `--tags level2-server` run skipped them and a Level 1 run wrongly included them
- templates/audit/98_auditd_exception.rules.j2 referenced the unprefixed `allow_auditd_uid_user_exclusions`; a bare undefined name in a Jinja `{% if %}` raises AnsibleUndefinedVariable, so enabling the exclusions feature failed the run
- prelim.yml gained the snap and squashfs discovery tasks: `templates/lockdown_audit.yml.j2` reads `prelim_snap_pkg_mgr` and `prelim_squashfs_builtin`, which this role never registered, so `ubtu24cis_squashfs_skip` always rendered false and the audit never skipped the control on a snap-based system
- 5.1.4: the goss vars emitted `AllowUsers`/`AllowGroups`/`DenyUsers`/`DenyGroups` even when the access list is empty, so the audit asserted the directive was present and failed on every host at default settings - the keyword now only renders with a non-empty list

**How has this been tested?:**
Manual and pipelines subscribers



**How has this been tested?:**
Please give an overview of how these changes were tested. If they were not please use N/A

